### PR TITLE
Fix order deletion bug

### DIFF
--- a/netlify/functions/sales.js
+++ b/netlify/functions/sales.js
@@ -132,7 +132,8 @@ export async function handler(event) {
 					const nu = Number(prev.qty_nute||0); if (nu) parts.push(`${nu} nute`);
 					const suffix = parts.length ? (' + ' + parts.join(' + ')) : '';
 					const msg = `Eliminada: ${name}${suffix}`;
-					await notifyDb({ type: 'delete', sellerId: Number(prev.seller_id||0)||null, saleId: id, saleDayId: Number(prev.sale_day_id||0)||null, message: msg, actorName: actor });
+					// Do not reference deleted sale_id to avoid FK violation
+					await notifyDb({ type: 'delete', sellerId: Number(prev.seller_id||0)||null, saleId: null, saleDayId: Number(prev.sale_day_id||0)||null, message: msg, actorName: actor });
 				}
 				return json({ ok: true });
 			}

--- a/netlify/functions/sales.js
+++ b/netlify/functions/sales.js
@@ -121,7 +121,7 @@ export async function handler(event) {
 				// fetch previous data for notification content
 				const prev = (await sql`SELECT seller_id, sale_day_id, client_name, qty_arco, qty_melo, qty_mara, qty_oreo, qty_nute FROM sales WHERE id=${id}`)[0] || null;
 				await sql`DELETE FROM sales WHERE id=${id}`;
-				// emit deletion notification with client and quantities
+				// emit deletion notification with client, quantities, and seller name
 				if (prev) {
 					const name = (prev.client_name || '') || 'Cliente';
 					const parts = [];
@@ -131,7 +131,13 @@ export async function handler(event) {
 					const or = Number(prev.qty_oreo||0); if (or) parts.push(`${or} oreo`);
 					const nu = Number(prev.qty_nute||0); if (nu) parts.push(`${nu} nute`);
 					const suffix = parts.length ? (' + ' + parts.join(' + ')) : '';
-					const msg = `Eliminada: ${name}${suffix}`;
+					let sellerName = '';
+					try {
+						const s = await sql`SELECT name FROM sellers WHERE id=${Number(prev.seller_id||0)}`;
+						sellerName = (s && s[0] && s[0].name) ? String(s[0].name) : '';
+					} catch {}
+					const tail = sellerName ? ` - ${sellerName}` : '';
+					const msg = `Eliminada: ${name}${suffix}${tail}`;
 					// Do not reference deleted sale_id to avoid FK violation
 					await notifyDb({ type: 'delete', sellerId: Number(prev.seller_id||0)||null, saleId: null, saleDayId: Number(prev.sale_day_id||0)||null, message: msg, actorName: actor });
 				}

--- a/public/app.js
+++ b/public/app.js
@@ -822,7 +822,13 @@ async function deleteRow(id) {
 	// Show immediate local toast for feedback; global notification will also arrive via polling
 	if (prev) {
 		try {
-			const msg = 'Eliminada: ' + formatSaleSummary(prev);
+			let sellerName = '';
+			try {
+				const match = (state.sellers || []).find(s => s && s.id === prev.seller_id);
+				sellerName = match && match.name ? String(match.name) : '';
+			} catch {}
+			const tail = sellerName ? (' - ' + sellerName) : '';
+			const msg = 'Eliminada: ' + formatSaleSummary(prev) + tail;
 			notify.info(msg);
 		} catch {}
 	}

--- a/public/app.js
+++ b/public/app.js
@@ -819,6 +819,13 @@ async function deleteRow(id) {
 	const actor = encodeURIComponent(state.currentUser?.name || '');
 	await api('DELETE', `${API.Sales}?id=${encodeURIComponent(id)}&actor=${actor}`);
 	state.sales = state.sales.filter(s => s.id !== id);
+	// Show immediate local toast for feedback; global notification will also arrive via polling
+	if (prev) {
+		try {
+			const msg = 'Eliminada: ' + formatSaleSummary(prev);
+			notify.info(msg);
+		} catch {}
+	}
 	// Push undo: re-create previous row
 	if (prev) {
 		pushUndo({


### PR DESCRIPTION
Set `saleId` to `null` when notifying about a deleted sale to prevent foreign key violations.

Previously, deleting a sale required two attempts because the first attempt failed silently due to a foreign key constraint violation when the notification tried to reference the already deleted `sale_id`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e2098c5-42e4-4e1b-b767-cc9975a6dc4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e2098c5-42e4-4e1b-b767-cc9975a6dc4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

