### PR TITLE
Ajustar posición del símbolo ®

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -796,8 +796,8 @@ tfoot td { font-weight: 700; }
 .col-client.has-reg { position: relative; }
 .client-reg-large {
 	position: absolute;
-	right: 6px;
-	top: 50%;
+	left: 6px;
+	top: 60%;
 	transform: translateY(-50%);
 	font-size: 28px;
 	line-height: 1;
@@ -805,7 +805,7 @@ tfoot td { font-weight: 700; }
 	color: var(--primary);
 	cursor: pointer;
 }
-.col-client.has-reg .client-input { padding-right: 44px; }
+.col-client.has-reg .client-input { padding-left: 36px; }
 .clients-row { cursor: pointer; }
 .clients-table tbody tr:hover td { background: #f3f4f6 !important; }
 [data-theme="dark"] .clients-table tbody tr:hover td { background: #1a1a1a !important; }


### PR DESCRIPTION
Adjust `®` symbol position to be closer to the client name and lower vertically.

---
<a href="https://cursor.com/background-agent?bcId=bc-6581ea9e-68da-4f87-bbb6-892da13f8084">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6581ea9e-68da-4f87-bbb6-892da13f8084">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

