### PR TITLE
Ajustar ancho columnas postres desktop

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -643,7 +643,7 @@ tfoot td { font-weight: 700; }
 
 /* Map CSS variables to colgroup widths for alignment */
 /* Widths including new Paid column */
-:root { --w-paid: 6%; --w-client: 40%; --w-qty: 9%; --w-total: 16%; --w-actions: 4%; }
+:root { --w-paid: 6%; --w-client: 40%; --w-qty: 7%; --w-total: 16%; --w-actions: 4%; }
 @media (max-width: 600px) { :root { --w-paid: 7%; --w-client: 49.5%; --w-qty: 6.5%; --w-total: 15.5%; --w-actions: 6%; } }
 
 /* Hide native thead to prevent overlap */
@@ -662,7 +662,7 @@ tfoot td { font-weight: 700; }
 #sales-table thead { display: none; }
 
 /* Rebalance widths to include Paid without overflow */
-:root { --w-paid: 6%; --w-client: 40%; --w-qty: 9%; --w-total: 16%; --w-actions: 5%; }
+:root { --w-paid: 6%; --w-client: 40%; --w-qty: 7%; --w-total: 16%; --w-actions: 5%; }
 @media (max-width: 600px) { :root { --w-paid: 7%; --w-client: 49.5%; --w-qty: 6.5%; --w-total: 15.5%; --w-actions: 6%; } }
 
 /* Revert Pago checkbox custom styles */


### PR DESCRIPTION
Adjust desktop `--w-qty` from 9% to 7% to make dessert columns slimmer.

---
<a href="https://cursor.com/background-agent?bcId=bc-01c64d7a-dbec-40fe-a8d9-0c1a56f5f9b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01c64d7a-dbec-40fe-a8d9-0c1a56f5f9b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

