### PR TITLE
Resolver conflictos de archivo de tablas de vendedores y acceso #145

### DIFF
--- a/netlify/functions/_db.js
+++ b/netlify/functions/_db.js
@@ -17,6 +17,7 @@ export async function ensureSchema() {
 		id SERIAL PRIMARY KEY,
 		name TEXT UNIQUE NOT NULL,
 		bill_color TEXT,
+		archived_at TIMESTAMPTZ,
 		created_at TIMESTAMPTZ DEFAULT now()
 	)`;
 	// Ensure bill_color exists for older deployments
@@ -26,6 +27,12 @@ export async function ensureSchema() {
 			WHERE table_name = 'sellers' AND column_name = 'bill_color'
 		) THEN
 			ALTER TABLE sellers ADD COLUMN bill_color TEXT;
+		END IF;
+		IF NOT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'sellers' AND column_name = 'archived_at'
+		) THEN
+			ALTER TABLE sellers ADD COLUMN archived_at TIMESTAMPTZ;
 		END IF;
 	END $$;`;
 	await sql`CREATE TABLE IF NOT EXISTS sale_days (


### PR DESCRIPTION
Implement logical archiving for sellers and add role-based access control to resolve conflicts from issue #145.

This PR introduces an `archived_at` column to the `sellers` table, enabling logical deletion. The `sellers.js` endpoint is updated to support archiving/unarchiving via `PATCH` and converts `DELETE` requests into archive operations. Role-based access control is enforced for `POST`, `PATCH`, and `DELETE` methods, and `GET` requests now filter out archived sellers by default.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0587f58-58b4-47ba-b686-e08d53bd1ec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0587f58-58b4-47ba-b686-e08d53bd1ec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

