### PR TITLE
Fix ingredient order not saving

### DIFF
--- a/netlify/functions/recipes.js
+++ b/netlify/functions/recipes.js
@@ -94,7 +94,7 @@ export async function handler(event) {
 					const id = Number(data.id || 0) || 0;
 					let row;
 					if (id) {
-						[row] = await sql`UPDATE dessert_recipe_items SET ingredient=${ingredient}, unit=${unit}, qty_per_unit=${qty}, adjustment=${adjustment}, price=${price}, position=${position}, updated_at=now() WHERE id=${id} RETURNING id, recipe_id, ingredient, unit, qty_per_unit, adjustment, price, position`;
+						[row] = await sql`UPDATE dessert_recipe_items SET recipe_id=${recipeId}, ingredient=${ingredient}, unit=${unit}, qty_per_unit=${qty}, adjustment=${adjustment}, price=${price}, position=${position}, updated_at=now() WHERE id=${id} RETURNING id, recipe_id, ingredient, unit, qty_per_unit, adjustment, price, position`;
 					} else {
 						[row] = await sql`INSERT INTO dessert_recipe_items (recipe_id, ingredient, unit, qty_per_unit, adjustment, price, position) VALUES (${recipeId}, ${ingredient}, ${unit}, ${qty}, ${adjustment}, ${price}, ${position}) RETURNING id, recipe_id, ingredient, unit, qty_per_unit, adjustment, price, position`;
 					}


### PR DESCRIPTION
Update `recipe_id` during item upsert to persist ingredient moves between steps.

Previously, when an ingredient was moved from one step to another, the `recipe_id` (which links the ingredient to its step) was not updated in the database during the `item.upsert` operation. This caused the ingredient to revert to its original step upon page reload. This change ensures `recipe_id` is updated, making the moves permanent.

---
<a href="https://cursor.com/background-agent?bcId=bc-51bef8ad-aa1c-4943-9e1d-5102fb505553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51bef8ad-aa1c-4943-9e1d-5102fb505553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

