### PR TITLE
Make actual purchases column editable for whatsapp

### DIFF
--- a/public/ingredients.html
+++ b/public/ingredients.html
@@ -274,7 +274,7 @@
 				// Real purchase based on pack size: ceil(buy / pack) * pack
 				const pack = Number(packMap.get(key) || 0) || 0;
 				const real = pack > 0 ? Math.ceil(buy / pack) * pack : buy;
-				const price = Number(priceMap.get(key) || 0) || 0;
+					const price = Number(priceMap.get(key) || 0) || 0;
 				const cost = real * price;
 				const perUnitDisplay = (v.perUnits && v.perUnits.size === 1) ? Array.from(v.perUnits)[0] : '—';
 				const tr = document.createElement('tr');
@@ -291,8 +291,8 @@
 				tbody.appendChild(tr);
 				buySugTotal += buy;
 					buyRealTotal += real;
-				buyCostTotal += Number(inCost.value || 0) || 0;
-					rowsState.push({ name: v.name, realInput: inReal, pack, costInput: inCost });
+					buyCostTotal += Number(inCost.value || 0) || 0;
+					rowsState.push({ name: v.name, realInput: inReal, pack, costInput: inCost, unitPrice: price });
 			}
 			function recomputeTotals(){
 				let t = 0; for (const r of rowsState) t += Number(r.costInput?.value || 0) || 0;
@@ -307,8 +307,15 @@
 				for (const r of rowsState) {
 					r.costInput.addEventListener('change', recomputeTotals);
 					r.costInput.addEventListener('blur', recomputeTotals);
-					r.realInput.addEventListener('change', recomputeRealTotal);
-					r.realInput.addEventListener('blur', recomputeRealTotal);
+					function onRealEdit(){
+						const realV = Number(r.realInput?.value || 0) || 0;
+						const unit = Number(r.unitPrice || 0) || 0;
+						r.costInput.value = String(Math.round(realV * unit));
+						recomputeRealTotal();
+						recomputeTotals();
+					}
+					r.realInput.addEventListener('change', onRealEdit);
+					r.realInput.addEventListener('blur', onRealEdit);
 				}
 			tBuySugTotal.textContent = fmt1(buySugTotal);
 				recomputeRealTotal();
@@ -319,16 +326,20 @@
 				const pop = document.createElement('div'); pop.className = 'confirm-popover'; pop.style.position = 'fixed';
 				pop.style.left = (window.innerWidth/2) + 'px'; pop.style.top = '12%'; pop.style.transform = 'translate(-50%, 0)';
 				const title = document.createElement('h4'); title.textContent = 'Solicitar compra por WhatsApp'; title.style.margin = '0 0 8px 0';
-				// Build WA lines on demand from current editable costs and real quantities
-				const freshLines = [];
+					// Build WA lines on demand using current edited quantities
+					const freshLines = [];
 					for (const r of rowsState) {
 						const realV = Number(r.realInput?.value || 0) || 0;
 						if (realV > 0) {
-							const costV = Number(r.costInput?.value || 0) || 0;
-							freshLines.push(`${r.name}: ${fmt1(realV)}${r.pack > 0 ? ` (paquete ${fmt1(r.pack)})` : ''}${costV>0 ? ` — ${new Intl.NumberFormat('es-CO',{style:'currency',currency:'COP',maximumFractionDigits:0}).format(costV)}` : ''}`);
+							if (Number(r.pack || 0) > 0) {
+								const pk = Math.max(1, Math.ceil(realV / Number(r.pack)));
+								freshLines.push(`${r.name} ${pk} paquete${pk===1?'':'s'}`);
+							} else {
+								freshLines.push(`${r.name} ${fmt1(realV)} unidades`);
+							}
 						}
 					}
-				const ta = document.createElement('textarea'); ta.style.width = 'min(92vw, 540px)'; ta.style.height = '260px'; ta.value = `Hola, por favor cotízame y despáchame:\n\n${freshLines.join('\n')}\n\nTotal estimado: ${new Intl.NumberFormat('es-CO',{style:'currency',currency:'COP',maximumFractionDigits:0}).format(buyCostTotal)}\n\nGracias!`;
+					const ta = document.createElement('textarea'); ta.style.width = 'min(92vw, 540px)'; ta.style.height = '260px'; ta.value = `${freshLines.join('\n')}\n\nTotal estimado: ${new Intl.NumberFormat('es-CO',{style:'currency',currency:'COP',maximumFractionDigits:0}).format(buyCostTotal)}`;
 				const actions = document.createElement('div'); actions.className = 'confirm-actions';
 				const copyBtn = document.createElement('button'); copyBtn.className = 'press-btn btn-primary'; copyBtn.textContent = 'Copiar';
 				const closeBtn = document.createElement('button'); closeBtn.className = 'press-btn'; closeBtn.textContent = 'Cerrar';

--- a/public/ingredients.html
+++ b/public/ingredients.html
@@ -267,7 +267,7 @@
 			let buySugTotal = 0; let buyRealTotal = 0; let buyCostTotal = 0;
 			const waLines = [];
 			const rowsState = [];
-			for (const key of keys){
+				for (const key of keys){
 				const v = agg.get(key);
 				const inv = invByKey.has(key) ? Number(invByKey.get(key)||0)||0 : 0;
 				const buy = Math.max(0, (Number(v.needed||0)||0) - inv);
@@ -283,39 +283,51 @@
 				const tdNeed = document.createElement('td'); tdNeed.textContent = fmt1(v.needed);
 				const tdInv = document.createElement('td'); tdInv.textContent = fmt1(inv);
 				const tdBuy = document.createElement('td'); tdBuy.className = 'col-total'; tdBuy.textContent = fmt1(buy);
-				const tdReal = document.createElement('td'); tdReal.textContent = fmt1(real);
+					const tdReal = document.createElement('td');
+					const inReal = document.createElement('input'); inReal.type = 'number'; inReal.step = '0.1'; inReal.min = '0'; inReal.className = 'input-cell'; inReal.style.width = '90px'; inReal.style.textAlign = 'right'; inReal.value = String(Number(fmt1(real))); tdReal.appendChild(inReal);
 				const tdCost = document.createElement('td');
 				const inCost = document.createElement('input'); inCost.type = 'number'; inCost.step = '1'; inCost.min = '0'; inCost.className = 'input-cell'; inCost.style.width = '110px'; inCost.style.textAlign = 'right'; inCost.value = String(Math.round(cost)); tdCost.appendChild(inCost);
-				tr.append(tdName, tdPer, tdNeed, tdInv, tdBuy, tdReal, tdCost);
+					tr.append(tdName, tdPer, tdNeed, tdInv, tdBuy, tdReal, tdCost);
 				tbody.appendChild(tr);
 				buySugTotal += buy;
-				buyRealTotal += real;
+					buyRealTotal += real;
 				buyCostTotal += Number(inCost.value || 0) || 0;
-				rowsState.push({ name: v.name, real, pack, costInput: inCost });
+					rowsState.push({ name: v.name, realInput: inReal, pack, costInput: inCost });
 			}
 			function recomputeTotals(){
 				let t = 0; for (const r of rowsState) t += Number(r.costInput?.value || 0) || 0;
 				buyCostTotal = t;
 				tBuyCostTotal.textContent = (new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', maximumFractionDigits: 0 })).format(buyCostTotal);
 			}
-			for (const r of rowsState) { r.costInput.addEventListener('change', recomputeTotals); r.costInput.addEventListener('blur', recomputeTotals); }
+				function recomputeRealTotal(){
+					let t = 0; for (const r of rowsState) t += Number(r.realInput?.value || 0) || 0;
+					buyRealTotal = t;
+					tBuyRealTotal.textContent = fmt1(buyRealTotal);
+				}
+				for (const r of rowsState) {
+					r.costInput.addEventListener('change', recomputeTotals);
+					r.costInput.addEventListener('blur', recomputeTotals);
+					r.realInput.addEventListener('change', recomputeRealTotal);
+					r.realInput.addEventListener('blur', recomputeRealTotal);
+				}
 			tBuySugTotal.textContent = fmt1(buySugTotal);
-			tBuyRealTotal.textContent = fmt1(buyRealTotal);
-			recomputeTotals();
+				recomputeRealTotal();
+				recomputeTotals();
 			countLabel.textContent = `Ingredientes: ${keys.length}`;
 			// Bind WA button to open a copyable text box
-			waBtn.onclick = () => {
+				waBtn.onclick = () => {
 				const pop = document.createElement('div'); pop.className = 'confirm-popover'; pop.style.position = 'fixed';
 				pop.style.left = (window.innerWidth/2) + 'px'; pop.style.top = '12%'; pop.style.transform = 'translate(-50%, 0)';
 				const title = document.createElement('h4'); title.textContent = 'Solicitar compra por WhatsApp'; title.style.margin = '0 0 8px 0';
 				// Build WA lines on demand from current editable costs and real quantities
 				const freshLines = [];
-				for (const r of rowsState) {
-					if (Number(r.real||0) > 0) {
-						const costV = Number(r.costInput?.value || 0) || 0;
-						freshLines.push(`${r.name}: ${fmt1(r.real)}${r.pack > 0 ? ` (paquete ${fmt1(r.pack)})` : ''}${costV>0 ? ` — ${new Intl.NumberFormat('es-CO',{style:'currency',currency:'COP',maximumFractionDigits:0}).format(costV)}` : ''}`);
+					for (const r of rowsState) {
+						const realV = Number(r.realInput?.value || 0) || 0;
+						if (realV > 0) {
+							const costV = Number(r.costInput?.value || 0) || 0;
+							freshLines.push(`${r.name}: ${fmt1(realV)}${r.pack > 0 ? ` (paquete ${fmt1(r.pack)})` : ''}${costV>0 ? ` — ${new Intl.NumberFormat('es-CO',{style:'currency',currency:'COP',maximumFractionDigits:0}).format(costV)}` : ''}`);
+						}
 					}
-				}
 				const ta = document.createElement('textarea'); ta.style.width = 'min(92vw, 540px)'; ta.style.height = '260px'; ta.value = `Hola, por favor cotízame y despáchame:\n\n${freshLines.join('\n')}\n\nTotal estimado: ${new Intl.NumberFormat('es-CO',{style:'currency',currency:'COP',maximumFractionDigits:0}).format(buyCostTotal)}\n\nGracias!`;
 				const actions = document.createElement('div'); actions.className = 'confirm-actions';
 				const copyBtn = document.createElement('button'); copyBtn.className = 'press-btn btn-primary'; copyBtn.textContent = 'Copiar';


### PR DESCRIPTION
Make 'Compras reales' column editable in 'Ingredientes necesarios' view to allow users to adjust quantities for WhatsApp messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f6a2208-4b9d-44e8-aae2-4bd806aec010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f6a2208-4b9d-44e8-aae2-4bd806aec010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

