### PR TITLE
Recalcular proyección de postres por ingresos

### DIFF
--- a/public/projections.html
+++ b/public/projections.html
@@ -504,22 +504,22 @@
 			let baseline = weeks.length ? Math.max(0, weeks[weeks.length-1].total) : Math.max(0, overallAvg);
 			for (let i=1;i<=horizonWeeks;i++){
 				baseline = Math.max(0, baseline * (1 + weeklyGrowth));
-				const base = baseline;
+				const baseMoney = baseline;
 				const isHigh = highWeeksSet.has(nextWeekStart);
 				const factor = isHigh ? highFactor : lowFactor;
-				const total = Math.max(0, base * factor);
-				// Meta de unidades por semana configurable: Quincena/Normal
-				const targetQ = Math.max(0, Number(targetQuincenaInput?.value || '100') || 0);
-				const targetN = Math.max(0, Number(targetNormalInput?.value || '60') || 0);
-				const targetUnits = isHigh ? targetQ : targetN;
-				// Elegimos el máximo entre unidades calculadas por precio promedio y la meta fija
+				const total = Math.max(0, baseMoney * factor);
+				// Unidades semanales basadas estrictamente en el total proyectado en dinero
 				const unitsCalc = avgPriceApprox > 0 ? Math.max(0, Math.round(total / avgPriceApprox)) : 0;
-				const unitsThisWeek = Math.max(unitsCalc, targetUnits);
-				const qa = Math.round(unitsThisWeek * wQa);
-				const qm = Math.round(unitsThisWeek * wQm);
-				const qma = Math.round(unitsThisWeek * wQma);
-				const qo = Math.round(unitsThisWeek * wQo);
-				const qn = Math.round(unitsThisWeek * wQn);
+				const unitsThisWeek = unitsCalc;
+				// Asignación por postre con redondeo de restos para conservar el total exacto
+				const shares = [wQa, wQm, wQma, wQo, wQn];
+				const raw = shares.map(s => unitsThisWeek * s);
+				const baseUnits = raw.map(x => Math.floor(x));
+				let allocated = baseUnits.reduce((a,b)=>a+b,0);
+				const need = Math.max(0, unitsThisWeek - allocated);
+				const fracIdx = raw.map((x,i)=>({ i, f: x - baseUnits[i] })).sort((a,b)=> b.f - a.f);
+				for (let k=0; k<need; k++){ baseUnits[fracIdx[k]?.i ?? 0]++; }
+				const [qa, qm, qma, qo, qn] = baseUnits;
 				const has15 = (() => { for (let d=0; d<7; d++){ const day = Number(addDaysIso(nextWeekStart,d).slice(8,10)); if (day===15) return true; } return false; })();
 				const has30 = (() => { for (let d=0; d<7; d++){ const day = Number(addDaysIso(nextWeekStart,d).slice(8,10)); if (day===30) return true; } return false; })();
 				let note = '';


### PR DESCRIPTION
Adjust dessert unit projections in `public/projections.html` to strictly derive from the weekly monetary total, removing fixed unit targets and ensuring the sum of units matches exactly.

Previously, the sum of projected dessert units could exceed the total implied by the monetary projection due to the use of fixed "target" units (e.g., Quincena/Normal). This change aligns the unit projections precisely with the weekly monetary forecast.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c236e66-4fb6-4e6d-aef3-fced3ac17920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c236e66-4fb6-4e6d-aef3-fced3ac17920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

