### PR TITLE
Autorizar acceso a cuentas de otros usuarios

### DIFF
--- a/netlify/functions/_db.js
+++ b/netlify/functions/_db.js
@@ -2,7 +2,7 @@ import { neon } from '@netlify/neon';
 
 const sql = neon(); // uses NETLIFY_DATABASE_URL
 let schemaEnsured = false;
-const SCHEMA_VERSION = 2; // Bump when schema changes require a migration
+const SCHEMA_VERSION = 3; // Bump when schema changes require a migration
 
 export async function ensureSchema() {
 	if (schemaEnsured) return;
@@ -58,6 +58,14 @@ export async function ensureSchema() {
 		seller_id INTEGER NOT NULL REFERENCES sellers(id) ON DELETE CASCADE,
 		created_at TIMESTAMPTZ DEFAULT now(),
 		UNIQUE (viewer_username, seller_id)
+	)`;
+	// Feature permissions: grant specific features to users (e.g., 'reports')
+	await sql`CREATE TABLE IF NOT EXISTS user_feature_permissions (
+		id SERIAL PRIMARY KEY,
+		username TEXT NOT NULL,
+		feature TEXT NOT NULL,
+		created_at TIMESTAMPTZ DEFAULT now(),
+		UNIQUE (username, feature)
 	)`;
 	await sql`CREATE TABLE IF NOT EXISTS sale_days (
 		id SERIAL PRIMARY KEY,

--- a/netlify/functions/users.js
+++ b/netlify/functions/users.js
@@ -82,12 +82,16 @@ export async function handler(event) {
 				if (rows.length) {
 					const user = rows[0];
 					if (user.password_hash !== password) return json({ error: 'Usuario o contraseña inválidos' }, 401);
-					return json({ username: user.username, role: user.role });
+					const featRows = await sql`SELECT feature FROM user_feature_permissions WHERE lower(username)=lower(${user.username}) ORDER BY feature ASC`;
+					const features = (featRows || []).map(f => String(f.feature));
+					return json({ username: user.username, role: user.role, features });
 				}
 				// Fallback: allow default rule for any username (legacy behavior)
 				const expected = username === 'jorge' ? 'Jorge123' : (username + 'sweet');
 				if ((expected || '').toLowerCase() !== (password || '').toLowerCase()) return json({ error: 'Usuario o contraseña inválidos' }, 401);
-				return json({ username: rawUsername, role: 'user' });
+				const featRows = await sql`SELECT feature FROM user_feature_permissions WHERE lower(username)=lower(${rawUsername}) ORDER BY feature ASC`;
+				const features = (featRows || []).map(f => String(f.feature));
+				return json({ username: rawUsername, role: 'user', features });
 			}
 			case 'PUT': {
 				// Change password

--- a/public/app.js
+++ b/public/app.js
@@ -675,13 +675,16 @@ function applyAuthVisibility() {
 	if (addSellerWrap) addSellerWrap.style.display = isSuper ? 'block' : 'none';
 	const usersBtn = document.getElementById('users-button');
 	if (usersBtn) usersBtn.style.display = isSuper ? 'inline-block' : 'none';
+    const reportBtn = document.getElementById('report-button');
     const carteraBtn = document.getElementById('cartera-button');
     const projectionsBtn = document.getElementById('projections-button');
     const transfersBtn = document.getElementById('transfers-button');
     const feats = new Set((state.currentUser?.features || []));
+    const canSales = isSuper || feats.has('reports.sales');
     const canCartera = isSuper || feats.has('reports.cartera');
     const canProjections = isSuper || feats.has('reports.projections');
     const canTransfers = isSuper || feats.has('reports.transfers');
+    if (reportBtn) reportBtn.style.display = canSales ? 'inline-block' : 'none';
     if (carteraBtn) carteraBtn.style.display = canCartera ? 'inline-block' : 'none';
     if (projectionsBtn) projectionsBtn.style.display = canProjections ? 'inline-block' : 'none';
     if (transfersBtn) transfersBtn.style.display = canTransfers ? 'inline-block' : 'none';
@@ -1692,6 +1695,9 @@ async function exportCarteraExcel(startIso, endIso) {
 	const input = document.getElementById('report-date');
 	if (!reportBtn || !input) return;
 	reportBtn.addEventListener('click', (ev) => {
+		const feats = new Set((state.currentUser?.features || []));
+		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
+		if (!isSuper && !feats.has('reports.sales')) { notify.error('Sin permiso de reporte de ventas'); return; }
 		openRangeCalendarPopover((range) => {
 			if (!range || !range.start || !range.end) return;
 			const url = `/sales-report.html?start=${encodeURIComponent(range.start)}&end=${encodeURIComponent(range.end)}`;
@@ -1699,8 +1705,9 @@ async function exportCarteraExcel(startIso, endIso) {
 		}, ev.clientX, ev.clientY, { preferUp: true });
 	});
 	projectionsBtn?.addEventListener('click', (ev) => {
+		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
-		if (!isSuper) { notify.error('Solo el superadministrador'); return; }
+		if (!isSuper && !feats.has('reports.projections')) { notify.error('Sin permiso de proyecciones'); return; }
 		openRangeCalendarPopover((range) => {
 			if (!range || !range.start || !range.end) return;
 			const url = `/projections.html?start=${encodeURIComponent(range.start)}&end=${encodeURIComponent(range.end)}`;
@@ -1708,8 +1715,9 @@ async function exportCarteraExcel(startIso, endIso) {
 		}, ev.clientX, ev.clientY, { preferUp: true });
 	});
 	carteraBtn?.addEventListener('click', async (ev) => {
+		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
-		if (!isSuper) { notify.error('Solo el superadministrador'); return; }
+		if (!isSuper && !feats.has('reports.cartera')) { notify.error('Sin permiso de cartera'); return; }
 		openRangeCalendarPopover(async (range) => {
 			if (!range || !range.start || !range.end) return;
 			await exportCarteraExcel(range.start, range.end);
@@ -1717,8 +1725,9 @@ async function exportCarteraExcel(startIso, endIso) {
 	});
 
 	transfersBtn?.addEventListener('click', (ev) => {
-		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
-		if (!isSuper) { notify.error('Solo el superadministrador'); return; }
+	const feats = new Set((state.currentUser?.features || []));
+	const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
+		if (!isSuper && !feats.has('reports.transfers')) { notify.error('Sin permiso de transferencias'); return; }
 		openRangeCalendarPopover((range) => {
 			if (!range || !range.start || !range.end) return;
 			const url = `/transfers.html?start=${encodeURIComponent(range.start)}&end=${encodeURIComponent(range.end)}`;

--- a/public/app.js
+++ b/public/app.js
@@ -674,24 +674,30 @@ function applyAuthVisibility() {
 	const addSellerWrap = document.querySelector('.seller-add');
 	if (addSellerWrap) addSellerWrap.style.display = isSuper ? 'block' : 'none';
 	const usersBtn = document.getElementById('users-button');
-	if (usersBtn) usersBtn.style.display = isSuper ? 'inline-block' : 'none';
-    const reportBtn = document.getElementById('report-button');
-    const carteraBtn = document.getElementById('cartera-button');
-    const projectionsBtn = document.getElementById('projections-button');
-    const transfersBtn = document.getElementById('transfers-button');
-    const feats = new Set((state.currentUser?.features || []));
-    const canSales = isSuper || feats.has('reports.sales');
-    const canCartera = isSuper || feats.has('reports.cartera');
-    const canProjections = isSuper || feats.has('reports.projections');
-    const canTransfers = isSuper || feats.has('reports.transfers');
-    if (reportBtn) reportBtn.style.display = canSales ? 'inline-block' : 'none';
-    if (carteraBtn) carteraBtn.style.display = canCartera ? 'inline-block' : 'none';
-    if (projectionsBtn) projectionsBtn.style.display = canProjections ? 'inline-block' : 'none';
-    if (transfersBtn) transfersBtn.style.display = canTransfers ? 'inline-block' : 'none';
+	const feats = new Set((state.currentUser?.features || []));
+	const reportBtn = document.getElementById('report-button');
+	const carteraBtn = document.getElementById('cartera-button');
+	const projectionsBtn = document.getElementById('projections-button');
+	const transfersBtn = document.getElementById('transfers-button');
 	const materialsBtn = document.getElementById('materials-button');
-	if (materialsBtn) materialsBtn.style.display = isSuper ? 'inline-block' : 'none';
+	const inventoryBtn = document.getElementById('inventory-button');
 	const accountingBtn = document.getElementById('accounting-button');
-	if (accountingBtn) accountingBtn.style.display = isSuper ? 'inline-block' : 'none';
+	const canSales = isSuper || feats.has('reports.sales');
+	const canCartera = isSuper || feats.has('reports.cartera');
+	const canProjections = isSuper || feats.has('reports.projections');
+	const canTransfers = isSuper || feats.has('reports.transfers');
+	const canMaterials = isSuper || feats.has('nav.materials');
+	const canInventory = isSuper || feats.has('nav.inventory');
+	const canUsers = isSuper || feats.has('nav.users');
+	const canAccounting = isSuper || feats.has('nav.accounting');
+	if (usersBtn) usersBtn.style.display = canUsers ? 'inline-block' : 'none';
+	if (reportBtn) reportBtn.style.display = canSales ? 'inline-block' : 'none';
+	if (carteraBtn) carteraBtn.style.display = canCartera ? 'inline-block' : 'none';
+	if (projectionsBtn) projectionsBtn.style.display = canProjections ? 'inline-block' : 'none';
+	if (transfersBtn) transfersBtn.style.display = canTransfers ? 'inline-block' : 'none';
+	if (materialsBtn) materialsBtn.style.display = canMaterials ? 'inline-block' : 'none';
+	if (inventoryBtn) inventoryBtn.style.display = canInventory ? 'inline-block' : 'none';
+	if (accountingBtn) accountingBtn.style.display = canAccounting ? 'inline-block' : 'none';
 }
 
 function calcRowTotal(q) {
@@ -1735,23 +1741,27 @@ async function exportCarteraExcel(startIso, endIso) {
 		}, ev.clientX, ev.clientY, { preferUp: true });
 	});
 	usersBtn?.addEventListener('click', async (ev) => {
+		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
-		if (!isSuper) { notify.error('Solo el superadministrador'); return; }
+		if (!isSuper && !feats.has('nav.users')) { notify.error('Sin permiso de usuarios'); return; }
 		openUsersMenu(ev.clientX, ev.clientY);
 	});
 	materialsBtn?.addEventListener('click', async (ev) => {
+		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
-		if (!isSuper) { notify.error('Solo el superadministrador'); return; }
+		if (!isSuper && !feats.has('nav.materials')) { notify.error('Sin permiso de materiales'); return; }
 		openMaterialsMenu(ev.clientX, ev.clientY);
 	});
 	inventoryBtn?.addEventListener('click', async (ev) => {
+		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
-		if (!isSuper) { notify.error('Solo el superadministrador'); return; }
+		if (!isSuper && !feats.has('nav.inventory')) { notify.error('Sin permiso de inventario'); return; }
 		openInventoryView();
 	});
 	accountingBtn?.addEventListener('click', (ev) => {
+		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
-		if (!isSuper) { notify.error('Solo el superadministrador'); return; }
+		if (!isSuper && !feats.has('nav.accounting')) { notify.error('Sin permiso de contabilidad'); return; }
 		window.location.href = '/accounting.html';
 	});
 })();
@@ -1859,7 +1869,7 @@ function openPermissionsManager() {
     const sellersLabel = document.createElement('label'); sellersLabel.textContent = 'Vendedores permitidos'; sellersLabel.style.display = 'block';
     const sellersBox = document.createElement('div'); sellersBox.style.display = 'grid'; sellersBox.style.gridTemplateColumns = 'repeat(2, minmax(0, 1fr))'; sellersBox.style.gap = '8px'; sellersBox.style.marginTop = '6px';
     right.appendChild(sellersLabel); right.appendChild(sellersBox);
-    const featureLabel = document.createElement('label'); featureLabel.textContent = 'Permisos de funcionalidades (reportes)'; featureLabel.style.display = 'block'; featureLabel.style.marginTop = '12px';
+    const featureLabel = document.createElement('label'); featureLabel.textContent = 'Permisos de funcionalidades'; featureLabel.style.display = 'block'; featureLabel.style.marginTop = '12px';
     function makeFeat(labelText, featureKey) {
         const wrap = document.createElement('label'); wrap.style.display = 'flex'; wrap.style.alignItems = 'center'; wrap.style.gap = '8px'; wrap.style.marginTop = '6px';
         const cb = document.createElement('input'); cb.type = 'checkbox'; cb.value = featureKey; cb.dataset.feature = featureKey;
@@ -1867,10 +1877,19 @@ function openPermissionsManager() {
         wrap.appendChild(cb); wrap.appendChild(span);
         return { wrap, cb };
     }
+    // Reports
+    const featSales = makeFeat('Ver botón Ventas', 'reports.sales');
+    const featTransfers = makeFeat('Ver botón Transferencias', 'reports.transfers');
     const featCartera = makeFeat('Ver botón Cartera', 'reports.cartera');
     const featProjections = makeFeat('Ver botón Proyecciones', 'reports.projections');
-    const featTransfers = makeFeat('Ver botón Transferencias', 'reports.transfers');
-    right.appendChild(featureLabel); right.appendChild(featCartera.wrap); right.appendChild(featProjections.wrap); right.appendChild(featTransfers.wrap);
+    // Nav
+    const featMaterials = makeFeat('Ver botón Materiales', 'nav.materials');
+    const featInventory = makeFeat('Ver botón Inventario', 'nav.inventory');
+    const featUsers = makeFeat('Ver botón Usuarios', 'nav.users');
+    const featAccounting = makeFeat('Ver botón Contabilidad', 'nav.accounting');
+    right.appendChild(featureLabel);
+    [featSales, featTransfers, featCartera, featProjections, featMaterials, featInventory, featUsers, featAccounting]
+        .forEach(x => right.appendChild(x.wrap));
     row.appendChild(left); row.appendChild(right);
     const actions = document.createElement('div'); actions.style.display = 'flex'; actions.style.justifyContent = 'flex-end'; actions.style.gap = '8px'; actions.style.marginTop = '14px';
     const closeBtn = document.createElement('button'); closeBtn.className = 'press-btn'; closeBtn.textContent = 'Cerrar';
@@ -1903,7 +1922,8 @@ function openPermissionsManager() {
             });
             const feats = await api('GET', API.Users + '?feature_permissions=1&username=' + encodeURIComponent(viewerName));
             const featuresSet = new Set((feats || []).map(f => String(f.feature)));
-            [featCartera.cb, featProjections.cb, featTransfers.cb].forEach(cb => { cb.checked = featuresSet.has(cb.dataset.feature); });
+            [featSales.cb, featTransfers.cb, featCartera.cb, featProjections.cb, featMaterials.cb, featInventory.cb, featUsers.cb, featAccounting.cb]
+                .forEach(cb => { cb.checked = featuresSet.has(cb.dataset.feature); });
         }
         userSelect.addEventListener('change', async () => {
             await loadViewerGrants(userSelect.value);
@@ -1924,7 +1944,8 @@ function openPermissionsManager() {
             for (const id of toRevoke) { await api('PATCH', API.Users, { action: 'revokeView', username: viewer, sellerId: id }); }
             const feats = await api('GET', API.Users + '?feature_permissions=1&username=' + encodeURIComponent(viewer));
             const currentFeat = new Set((feats || []).map(f => String(f.feature)));
-            const desiredFeat = new Set([featCartera.cb, featProjections.cb, featTransfers.cb].filter(cb => cb.checked).map(cb => cb.dataset.feature));
+            const desiredFeat = new Set([featSales.cb, featTransfers.cb, featCartera.cb, featProjections.cb, featMaterials.cb, featInventory.cb, featUsers.cb, featAccounting.cb]
+                .filter(cb => cb.checked).map(cb => cb.dataset.feature));
             const toGrantF = [...desiredFeat].filter(f => !currentFeat.has(f));
             const toRevokeF = [...currentFeat].filter(f => !desiredFeat.has(f));
             for (const f of toGrantF) await api('PATCH', API.Users, { action: 'grantFeature', username: viewer, feature: f });

--- a/public/app.js
+++ b/public/app.js
@@ -515,6 +515,7 @@ function bindLogin() {
 				state.currentUser = { name: res.username, isAdmin: res.role === 'admin' || res.role === 'superadmin', role: res.role, isSuperAdmin: res.role === 'superadmin' };
 				try { localStorage.setItem('authUser', JSON.stringify(state.currentUser)); } catch {}
 				applyAuthVisibility();
+				await loadSellers();
 				renderSellerButtons();
 				const usernameLower = String(res.username || '').toLowerCase();
 				const feminineUsers = new Set(['marcela', 'aleja', 'kate', 'stefa', 'mariana', 'janeth']);

--- a/public/app.js
+++ b/public/app.js
@@ -512,7 +512,7 @@ function bindLogin() {
 			try {
 				const res = await api('POST', API.Users, { username: user, password: pass });
 				if (err) err.classList.add('hidden');
-				state.currentUser = { name: res.username, isAdmin: res.role === 'admin' || res.role === 'superadmin', role: res.role, isSuperAdmin: res.role === 'superadmin' };
+				state.currentUser = { name: res.username, isAdmin: res.role === 'admin' || res.role === 'superadmin', role: res.role, isSuperAdmin: res.role === 'superadmin', features: Array.isArray(res.features) ? res.features : [] };
 				try { localStorage.setItem('authUser', JSON.stringify(state.currentUser)); } catch {}
 				applyAuthVisibility();
 				await loadSellers();
@@ -4492,6 +4492,7 @@ function openReceiptViewerPopover(imageBase64, saleId, createdAt, anchorX, ancho
 		state.currentUser.role = getRole(name);
 		state.currentUser.isSuperAdmin = isSuperAdmin(name);
 		state.currentUser.isAdmin = isAdmin(name);
+		state.currentUser.features = Array.isArray(state.currentUser.features) ? state.currentUser.features : [];
 		try { localStorage.setItem('authUser', JSON.stringify(state.currentUser)); } catch {}
 	}
 	await loadSellers();

--- a/public/index.html
+++ b/public/index.html
@@ -430,6 +430,6 @@
 	<!-- Toast container -->
 	<div id="toast-container" aria-live="polite" aria-atomic="true"></div>
 
-	<script src="/app.js?v=2025-09-17-1" type="module"></script>
+	<script src="/app.js?v=2025-10-02-1" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
Implement delegated view permissions for users to see specific authorized sellers' data.

This change introduces a `user_view_permissions` table and enforces access control in `sellers.js`, `days.js`, and `sales.js` to allow regular users to view data for sellers explicitly granted by a superadmin. Superadmins can manage these permissions via new `grantView` and `revokeView` actions on `PATCH /api/users` and corresponding UI buttons.

---
<a href="https://cursor.com/background-agent?bcId=bc-552c3720-9982-43ff-890e-7e027209007b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-552c3720-9982-43ff-890e-7e027209007b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

