### PR TITLE
Fix sales report date range display

### DIFF
--- a/public/ingredients.html
+++ b/public/ingredients.html
@@ -69,6 +69,8 @@
 		const qs = new URLSearchParams(location.search);
 		let start = (qs.get('start') || '').slice(0,10);
 		let end = (qs.get('end') || '').slice(0,10);
+		let actor = (qs.get('actor') || '').toString();
+		if (!actor) { try { const saved = JSON.parse(localStorage.getItem('authUser')||'null'); actor = (saved?.name||saved?.username||'').toString(); } catch {} }
 		const rangeLabel = document.getElementById('range-label');
 		const countLabel = document.getElementById('count-label');
 		const countsSummary = document.getElementById('counts-summary');
@@ -114,6 +116,14 @@
 
 		async function fetchJSON(u){ const r = await fetch(u); if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }
 
+		function withActor(url){
+			try {
+				const u = new URL(url, location.origin);
+				if (actor) u.searchParams.set('actor', actor);
+				return u.pathname + (u.search || '');
+			} catch { return url + (url.includes('?') ? `&actor=${encodeURIComponent(actor)}` : `?actor=${encodeURIComponent(actor)}`); }
+		}
+
 		function sumCountsView(c){
 			countsSummary.innerHTML = '';
 			const pills = [
@@ -136,7 +146,7 @@
 			openRangeCalendarPopover((range) => {
 				if (!range || !range.start || !range.end) return;
 				start = range.start; end = range.end;
-				history.replaceState(null, '', `?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`);
+				history.replaceState(null, '', `?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}${actor?`&actor=${encodeURIComponent(actor)}`:''}`);
 				load();
 			}, ev.clientX, ev.clientY, { preferUp: true });
 		}
@@ -146,7 +156,7 @@
 			rangeLabel.textContent = `${formatDay(start)} — ${formatDay(end)}`;
 			countLabel.textContent = 'Cargando…';
 			// 1) Build counts by dessert from sales in range
-			const sellers = await fetchJSON('/api/sellers');
+			const sellers = await fetchJSON(withActor('/api/sellers'));
 			countLabel.textContent = `Vendedores: ${sellers.length} · Buscando días…`;
 			const isoBetween = (iso, a, b) => iso >= a && iso <= b;
 			async function mapLimit(items, limit, fn) {
@@ -163,7 +173,7 @@
 			const sellerDays = [];
 			await mapLimit(sellers, 6, async (s) => {
 				try {
-					const days = await fetchJSON(`/api/days?seller_id=${encodeURIComponent(s.id)}`);
+					const days = await fetchJSON(withActor(`/api/days?seller_id=${encodeURIComponent(s.id)}`));
 					for (const d of (days||[])) {
 						const iso = String(d.day).slice(0,10);
 						if (isoBetween(iso, start, end)) sellerDays.push({ seller: s, day: d });
@@ -175,7 +185,7 @@
 			await mapLimit(sellerDays, 6, async ({ seller, day }) => {
 				try {
 					const params = new URLSearchParams({ seller_id: String(seller.id), sale_day_id: String(day.id) });
-					const sales = await fetchJSON(`/api/sales?${params.toString()}`);
+					const sales = await fetchJSON(withActor(`/api/sales?${params.toString()}`));
 					for (const r of (sales || [])) {
 						counts.arco += Number(r.qty_arco || 0) || 0;
 						counts.melo += Number(r.qty_melo || 0) || 0;
@@ -189,7 +199,7 @@
 
 			// 2) Fetch recipes and extras once (batched)
 			countLabel.textContent = 'Cargando recetas…';
-			const all = await fetchJSON('/api/recipes?all_items=1&include_extras=1');
+			const all = await fetchJSON(withActor('/api/recipes?all_items=1&include_extras=1'));
 			const names = Array.isArray(all?.desserts) ? all.desserts : [];
 			const extras = Array.isArray(all?.extras) ? all.extras : [];
 			const itemsByDessert = new Map();
@@ -203,7 +213,7 @@
 
 			// 3) Fetch inventory balances
 			countLabel.textContent = 'Leyendo inventario…';
-			const inventory = await fetchJSON('/api/inventory');
+			const inventory = await fetchJSON(withActor('/api/inventory'));
 			const invByKey = new Map();
 			for (const it of (inventory||[])) invByKey.set((it.ingredient||'').toString().toLowerCase(), Number(it.saldo||0)||0);
 
@@ -509,9 +519,10 @@
 
 			// Back to report or home
 		backBtn.addEventListener('click', () => {
-			const url = new URL('/sales-report.html', location.origin);
+		const url = new URL('/sales-report.html', location.origin);
 			if (start) url.searchParams.set('start', start);
 			if (end) url.searchParams.set('end', end);
+			if (actor) url.searchParams.set('actor', actor);
 			location.href = url.toString();
 		});
 		changeBtn.addEventListener('click', openCalendar);
@@ -519,6 +530,7 @@
 			const url = new URL('/receta.html', location.origin);
 			if (start) url.searchParams.set('start', start);
 			if (end) url.searchParams.set('end', end);
+			if (actor) url.searchParams.set('actor', actor);
 			location.href = url.toString();
 		});
 
@@ -531,7 +543,7 @@
 			openRangeCalendarPopover((range) => {
 				if (!range || !range.start || !range.end) return;
 				start = range.start; end = range.end;
-				history.replaceState(null, '', `?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`);
+				history.replaceState(null, '', `?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}${actor?`&actor=${encodeURIComponent(actor)}`:''}`);
 				load();
 			}, cx, cy, { preferUp: true });
 		} else {

--- a/public/sales-report.html
+++ b/public/sales-report.html
@@ -101,6 +101,9 @@
 		const qs = new URLSearchParams(location.search);
 		let start = (qs.get('start') || '').slice(0,10);
 		let end = (qs.get('end') || '').slice(0,10);
+		// Try to infer current actor from localStorage set by index page
+		let actor = '';
+		try { const saved = JSON.parse(localStorage.getItem('authUser')||'null'); actor = (saved?.name||saved?.username||'').toString(); } catch {}
 		const rangeLabel = document.getElementById('range-label');
 		const countLabel = document.getElementById('count-label');
 		const tbody = document.getElementById('report-tbody');
@@ -139,6 +142,14 @@
 		}
 
 		async function fetchJSON(u){ const r = await fetch(u); if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }
+
+		function withActor(url){
+			try {
+				const u = new URL(url, location.origin);
+				if (actor) u.searchParams.set('actor', actor);
+				return u.pathname + (u.search || '');
+			} catch { return url + (url.includes('?') ? `&actor=${encodeURIComponent(actor)}` : `?actor=${encodeURIComponent(actor)}`); }
+		}
 
 		function populateFilters(){
 			// Sellers
@@ -269,7 +280,7 @@
 			const sellerDays = [];
 			await mapLimit(sellersList, 6, async (s) => {
 				try {
-					const days = await fetchJSON(`/api/days?seller_id=${encodeURIComponent(s.id)}`);
+				const days = await fetchJSON(withActor(`/api/days?seller_id=${encodeURIComponent(s.id)}`));
 					for (const d of (days||[])) {
 						const iso = String(d.day).slice(0,10);
 						if (isoBetween(iso, start, end)) sellerDays.push({ seller: s, day: d });
@@ -281,7 +292,7 @@
 			await mapLimit(sellerDays, 6, async ({ seller, day }) => {
 				try {
 					const params = new URLSearchParams({ seller_id: String(seller.id), sale_day_id: String(day.id) });
-					const sales = await fetchJSON(`/api/sales?${params.toString()}`);
+					const sales = await fetchJSON(withActor(`/api/sales?${params.toString()}`));
 					for (const r of (sales || [])) {
 						const qa = r.qty_arco || 0; const qm = r.qty_melo || 0; const qma = r.qty_mara || 0; const qo = r.qty_oreo || 0; const qn = r.qty_nute || 0; const tot = r.total_cents || 0;
 						dataset.push({

--- a/public/sales-report.html
+++ b/public/sales-report.html
@@ -101,9 +101,9 @@
 		const qs = new URLSearchParams(location.search);
 		let start = (qs.get('start') || '').slice(0,10);
 		let end = (qs.get('end') || '').slice(0,10);
-		// Try to infer current actor from localStorage set by index page
-		let actor = '';
-		try { const saved = JSON.parse(localStorage.getItem('authUser')||'null'); actor = (saved?.name||saved?.username||'').toString(); } catch {}
+		// Actor can come from URL or localStorage (set by index page)
+		let actor = (qs.get('actor') || '').toString();
+		if (!actor) { try { const saved = JSON.parse(localStorage.getItem('authUser')||'null'); actor = (saved?.name||saved?.username||'').toString(); } catch {} }
 		const rangeLabel = document.getElementById('range-label');
 		const countLabel = document.getElementById('count-label');
 		const tbody = document.getElementById('report-tbody');
@@ -260,7 +260,7 @@
 			rangeLabel.textContent = `${formatDay(start)} — ${formatDay(end)}`;
 			countLabel.textContent = 'Cargando…';
 			dataset = [];
-			sellersList = await fetchJSON('/api/sellers');
+			sellersList = await fetchJSON(withActor('/api/sellers'));
 			populateFilters();
 			countLabel.textContent = `Vendedores: ${sellersList.length} · Buscando días…`;
 			const isoBetween = (iso, a, b) => iso >= a && iso <= b;
@@ -313,7 +313,7 @@
 			openRangeCalendarPopover((range) => {
 				if (!range || !range.start || !range.end) return;
 				start = range.start; end = range.end;
-				history.replaceState(null, '', `?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`);
+			history.replaceState(null, '', `?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}${actor?`&actor=${encodeURIComponent(actor)}`:''}`);
 				load();
 			}, ev.clientX, ev.clientY, { preferUp: true });
 		}

--- a/public/sales-report.html
+++ b/public/sales-report.html
@@ -359,6 +359,7 @@
 			const url = new URL('/ingredients.html', location.origin);
 			if (start) url.searchParams.set('start', start);
 			if (end) url.searchParams.set('end', end);
+			if (actor) url.searchParams.set('actor', actor);
 			location.href = url.toString();
 		});
 


### PR DESCRIPTION
Add `actor` parameter to sales report API requests to correctly apply user permissions.

Previously, the sales report page did not include the logged-in user's `actor` in API calls to `/api/days` and `/api/sales`. This resulted in empty reports for non-admin users because the backend's permission checks failed without this context. This change reads the `actor` from `localStorage` and appends it to ensure proper data retrieval.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3a38cd1-1c17-43a0-9d52-5d2b491037c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3a38cd1-1c17-43a0-9d52-5d2b491037c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

