### PR TITLE
Agregar y eliminar vendedor para superadmin

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -630,6 +630,8 @@ function renderSellerButtons() {
                     await api('DELETE', `${API.Sellers}?id=${encodeURIComponent(s.id)}`);
                     // Remove locally and re-render
                     state.sellers = state.sellers.filter(x => x.id !== s.id);
+                    // Exit delete mode after successful deletion
+                    state.deleteSellerMode = false;
                     notify.success('Vendedor eliminado');
                     renderSellerButtons();
                 } catch (e) {
@@ -641,6 +643,13 @@ function renderSellerButtons() {
         } }, s.name);
         if (isSuper && state.deleteSellerMode) btn.classList.add('delete-mode');
         list.appendChild(btn);
+    }
+}
+
+function exitDeleteSellerModeIfActive() {
+    if (state.deleteSellerMode) {
+        state.deleteSellerMode = false;
+        renderSellerButtons();
     }
 }
 
@@ -1721,6 +1730,7 @@ async function exportCarteraExcel(startIso, endIso) {
 	const input = document.getElementById('report-date');
 	if (!reportBtn || !input) return;
 	reportBtn.addEventListener('click', (ev) => {
+		exitDeleteSellerModeIfActive();
 		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
 		if (!isSuper && !feats.has('reports.sales')) { notify.error('Sin permiso de reporte de ventas'); return; }
@@ -1731,6 +1741,7 @@ async function exportCarteraExcel(startIso, endIso) {
 		}, ev.clientX, ev.clientY, { preferUp: true });
 	});
 	projectionsBtn?.addEventListener('click', (ev) => {
+		exitDeleteSellerModeIfActive();
 		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
 		if (!isSuper && !feats.has('reports.projections')) { notify.error('Sin permiso de proyecciones'); return; }
@@ -1741,6 +1752,7 @@ async function exportCarteraExcel(startIso, endIso) {
 		}, ev.clientX, ev.clientY, { preferUp: true });
 	});
     carteraBtn?.addEventListener('click', (ev) => {
+        exitDeleteSellerModeIfActive();
         const feats = new Set((state.currentUser?.features || []));
         const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
         if (!isSuper && !feats.has('reports.cartera')) { notify.error('Sin permiso de cartera'); return; }
@@ -1752,6 +1764,7 @@ async function exportCarteraExcel(startIso, endIso) {
     });
 
 	transfersBtn?.addEventListener('click', (ev) => {
+		exitDeleteSellerModeIfActive();
 	const feats = new Set((state.currentUser?.features || []));
 	const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
 		if (!isSuper && !feats.has('reports.transfers')) { notify.error('Sin permiso de transferencias'); return; }
@@ -1762,24 +1775,28 @@ async function exportCarteraExcel(startIso, endIso) {
 		}, ev.clientX, ev.clientY, { preferUp: true });
 	});
 	usersBtn?.addEventListener('click', async (ev) => {
+		exitDeleteSellerModeIfActive();
 		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
 		if (!isSuper && !feats.has('nav.users')) { notify.error('Sin permiso de usuarios'); return; }
 		openUsersMenu(ev.clientX, ev.clientY);
 	});
-	materialsBtn?.addEventListener('click', async (ev) => {
+    materialsBtn?.addEventListener('click', async (ev) => {
+        exitDeleteSellerModeIfActive();
 		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
 		if (!isSuper && !feats.has('nav.materials')) { notify.error('Sin permiso de materiales'); return; }
 		openMaterialsMenu(ev.clientX, ev.clientY);
 	});
-	inventoryBtn?.addEventListener('click', async (ev) => {
+    inventoryBtn?.addEventListener('click', async (ev) => {
+        exitDeleteSellerModeIfActive();
 		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
 		if (!isSuper && !feats.has('nav.inventory')) { notify.error('Sin permiso de inventario'); return; }
 		openInventoryView();
 	});
-	accountingBtn?.addEventListener('click', (ev) => {
+    accountingBtn?.addEventListener('click', (ev) => {
+        exitDeleteSellerModeIfActive();
 		const feats = new Set((state.currentUser?.features || []));
 		const isSuper = state.currentUser?.role === 'superadmin' || !!state.currentUser?.isSuperAdmin;
 		if (!isSuper && !feats.has('nav.accounting')) { notify.error('Sin permiso de contabilidad'); return; }
@@ -2063,7 +2080,7 @@ function bindEvents() {
         } catch {}
     });
 
-	$('#add-row').addEventListener('click', addRow);
+    $('#add-row').addEventListener('click', addRow);
 	$('#go-home').addEventListener('click', () => {
 		state.currentSeller = null;
 		state.sales = [];

--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,8 @@
 				<div class="panel-body">
 					<div id="seller-list" class="seller-list"></div>
 					<div class="seller-add">
-						<button id="add-seller" class="press-btn add-seller-wide">+ Agregar Nuevo Vendedor</button>
+						<button id="add-seller" class="press-btn add-seller-wide">Agregar vendedor</button>
+						<button id="delete-seller" class="press-btn add-seller-wide">Eliminar vendedor</button>
 					</div>
 				</div>
 			</div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -258,9 +258,21 @@ main { padding: 24px; max-width: 1024px; margin: 0 auto; }
 }
 .seller-button:hover { background: var(--hover-primary-pink); color: #ffffff; box-shadow: 0 8px 24px var(--hover-shadow-pink); }
 
-.seller-add { margin: 12px 0; padding: 0; background: transparent; border: none; box-shadow: none; }
+.seller-add { margin: 12px 0; padding: 0; background: transparent; border: none; box-shadow: none; display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
 .add-seller-wide { display: block; width: 100%; padding: 14px 16px; border-radius: 16px; background: #fbf7f0; border: 1px solid var(--border); color: var(--text); font-weight: 400; font-size: 10px; box-shadow: 0 1px 2px rgba(0,0,0,0.06); }
 .add-seller-wide:hover { background: #f2e2d3; }
+
+/* Delete seller mode style hint on buttons */
+.seller-button.delete-mode { position: relative; border-color: var(--danger); }
+.seller-button.delete-mode::after {
+  content: '';
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px; height: 16px;
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="%23ef4444" d="M7 4h10l-1 2h4v2H4V6h4l-1-2zm-1 6h12l-1 10H7L6 10zm3 2v6h2v-6H9zm4 0v6h2v-6h-2z"/></svg>') no-repeat center / contain;
+}
 
 select, input[type="text"], button {
 	padding: 10px 12px;


### PR DESCRIPTION
Add superadmin-only "Eliminar vendedor" button and delete mode for managing sellers.

This feature allows superadmins to toggle a delete mode, which displays trash icons next to seller buttons. Clicking a seller in this mode prompts for confirmation before deleting the seller via an API call. The delete mode can be exited by clicking "Eliminar vendedor" again or "Agregar vendedor".

---
<a href="https://cursor.com/background-agent?bcId=bc-674ac1c3-128c-469b-bec1-34cf1f55b3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-674ac1c3-128c-469b-bec1-34cf1f55b3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

