### PR TITLE
Autocompletar nombres de clientes en ventas

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4257,14 +4257,11 @@ function updateClientDatalistForQuery(queryRaw) {
     const dl = ensureClientDatalist();
     const list = Array.isArray(state.clientSuggestions) ? state.clientSuggestions : [];
     const q = normalizeClientName(queryRaw || '');
-    let filtered = list;
-    if (q) {
-        filtered = list.filter(it => it.key.startsWith(q) || normalizeClientName(it.name).includes(q));
-    }
-    // Limit number of suggestions to keep UI compact
-    filtered = filtered.slice(0, 12);
-    // Rebuild <option> list
+    // Rebuild <option> list and only show suggestions when user typed something
     dl.innerHTML = '';
+    if (!q) return; // do not show any options until typing begins
+    // Strict prefix match by typed sequence
+    const filtered = list.filter(it => (it.key || '').startsWith(q)).slice(0, 12);
     for (const it of filtered) {
         const opt = document.createElement('option');
         opt.value = it.name;
@@ -4281,7 +4278,7 @@ function wireClientAutocompleteForInput(inputEl) {
     // Avoid duplicate listeners
     if (inputEl.dataset.autoCompleteBound === '1') { refresh(); return; }
     inputEl.dataset.autoCompleteBound = '1';
-    inputEl.addEventListener('focus', refresh);
+    // Show suggestions only after typing begins
     inputEl.addEventListener('input', refresh);
 }
 


### PR DESCRIPTION
Add client name autocomplete to the sales table to allow sellers to quickly select regular client names.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf19f564-1659-4d7d-ab37-53d655e24974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf19f564-1659-4d7d-ab37-53d655e24974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

