### PR TITLE
Fix dessert creation dialog loop

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2686,16 +2686,17 @@ async function renderIngredientsView() {
 		if (after == null) grid.appendChild(dragging); else grid.insertBefore(dragging, after);
 	});
 	root.appendChild(grid);
-	// Top actions
-	const addDessertBtn = document.getElementById('ingredients-add-dessert');
-	addDessertBtn?.addEventListener('click', async () => {
-		const name = (prompt('Nombre del postre:') || '').trim(); if (!name) return;
-		await api('POST', API.Recipes, { kind: 'step.upsert', dessert: name, step_name: null, position: 0 });
-		await renderIngredientsView();
-		try { document.dispatchEvent(new CustomEvent('recipes:changed', { detail: { action: 'addDessert', dessert: name } })); } catch {}
-	});
-	const extrasBtn = document.getElementById('ingredients-add-extras');
-	extrasBtn?.addEventListener('click', async () => { openExtrasEditor(); });
+    // Top actions (use onclick to avoid duplicate listeners on re-render)
+    const addDessertBtn = document.getElementById('ingredients-add-dessert');
+    if (addDessertBtn) addDessertBtn.onclick = async () => {
+        const name = (prompt('Nombre del postre:') || '').trim();
+        if (!name) return;
+        await api('POST', API.Recipes, { kind: 'step.upsert', dessert: name, step_name: null, position: 0 });
+        await renderIngredientsView();
+        try { document.dispatchEvent(new CustomEvent('recipes:changed', { detail: { action: 'addDessert', dessert: name } })); } catch {}
+    };
+    const extrasBtn = document.getElementById('ingredients-add-extras');
+    if (extrasBtn) extrasBtn.onclick = () => { openExtrasEditor(); };
 }
 
 // ====== Local-only TIEMPOS ======


### PR DESCRIPTION
Replace `addEventListener` with `onclick` for dessert creation dialog to prevent multiple prompts on re-render.

---
<a href="https://cursor.com/background-agent?bcId=bc-46e1772d-574b-4102-a044-50f0eb0eead1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46e1772d-574b-4102-a044-50f0eb0eead1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

