### PR TITLE
Remove the bottom new order button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -219,9 +219,6 @@
 				<div class="table-actions end">
 					
 				</div>
-				<div class="table-actions end">
-					<button id="add-row-bottom" class="press-btn btn-primary">Nuevo pedido</button>
-				</div>
 			</div>
 		</section>
 


### PR DESCRIPTION
Remove the bottom "Nuevo pedido" button as per user request to only have two "new order" buttons.

---
<a href="https://cursor.com/background-agent?bcId=bc-107496f7-f396-409b-91c6-24f7f431c7c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-107496f7-f396-409b-91c6-24f7f431c7c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

