### PR TITLE
Compare Neon and AWS costs

### DIFF
--- a/ANALISIS_COSTOS_NEON_VS_AWS.md
+++ b/ANALISIS_COSTOS_NEON_VS_AWS.md
@@ -1,0 +1,217 @@
+# Análisis de Costos: Neon vs AWS para Sweet Lab
+
+## Resumen de tu Aplicación
+
+- **Tipo**: Aplicación de gestión de ventas de postres
+- **Arquitectura**: Netlify (hosting + funciones serverless) + Base de datos PostgreSQL
+- **Funciones**: 13 funciones serverless (sellers, sales, desserts, inventory, accounting, etc.)
+- **Tablas DB**: ~20 tablas (users, sellers, sales, desserts, inventory, recipes, notifications, etc.)
+- **Patrón de uso**: Negocio pequeño/mediano, tráfico bajo-medio, picos en horarios de venta
+
+---
+
+## 🎯 RESPUESTA RÁPIDA: ¿Cuál te sale más costoso?
+
+### **AWS sería MUCHO MÁS COSTOSO** para tu caso
+
+**Estimación mensual:**
+- **Neon**: $0 - $19 USD/mes
+- **AWS (RDS)**: $30 - $150+ USD/mes
+
+---
+
+## Análisis Detallado
+
+### 1. NEON (Recomendado para tu caso)
+
+#### Plan Gratuito (Free Tier)
+- ✅ **Costo**: $0/mes
+- ✅ **Límites**:
+  - 0.5 GB de almacenamiento
+  - Límite de 10 ramas (branches)
+  - Inactividad después de 5 minutos (se reactiva automáticamente)
+  - 100 horas de cómputo activo/mes
+
+**¿Es suficiente para ti?**
+- **Almacenamiento**: Sí (ventas, inventario, recetas = probablemente < 100 MB)
+- **Cómputo**: Sí (100 horas = ~3.3 horas/día de actividad de DB)
+- **Latencia**: Baja (<1s para reactivar desde inactividad)
+
+#### Plan Launch ($19/mes)
+Si creces un poco:
+- ✅ 10 GB de almacenamiento
+- ✅ 300 horas de cómputo/mes
+- ✅ Sin período de inactividad
+- ✅ Backups automáticos
+
+**Ventajas de Neon para tu caso:**
+1. **Serverless real**: Solo pagas por uso activo
+2. **Integración nativa con Netlify**: Ya lo tienes configurado
+3. **Auto-scaling**: Escala automáticamente según demanda
+4. **Sin administración**: No necesitas configurar nada
+5. **Branches de DB**: Puedes crear ramas para testing (gratis)
+
+---
+
+### 2. AWS RDS/Aurora
+
+#### Opción 1: RDS PostgreSQL (instancia tradicional)
+
+**Instancia más pequeña (db.t4g.micro)**:
+- 💰 **Costo base**: ~$12-15/mes (instancia)
+- 💰 **Almacenamiento**: $0.10/GB/mes × 20 GB = $2/mes
+- 💰 **Backups**: $0.095/GB/mes
+- 💰 **I/O operations**: Variables
+- 💰 **Data transfer**: $0.09/GB (después de 1GB gratis)
+- 💰 **Total estimado**: **$30-50/mes mínimo**
+
+**Problemas para tu caso:**
+- ❌ Instancia siempre corriendo (24/7) aunque no tengas tráfico
+- ❌ Debes administrar: backups, actualizaciones, seguridad
+- ❌ Debes configurar: VPC, security groups, subnet groups
+- ❌ Latencia adicional si no está en la misma región que Netlify
+- ❌ Escalabilidad manual (debes cambiar el tipo de instancia)
+
+#### Opción 2: Aurora Serverless v2
+
+**Costos:**
+- 💰 **ACUs mínimos**: 0.5 ACU = $0.12/hora = **$87/mes** (mínimo, siempre activo)
+- 💰 **Almacenamiento**: $0.10/GB/mes
+- 💰 **I/O**: $0.20 por millón de requests
+- 💰 **Total estimado**: **$100-150/mes mínimo**
+
+**Problemas para tu caso:**
+- ❌ **MUY CARO** para aplicaciones pequeñas
+- ❌ Configuración compleja
+- ❌ Requiere VPC, subnets, NAT gateway (costos adicionales)
+- ❌ Los mínimos ACUs siguen siendo caros para bajo tráfico
+
+#### Opción 3: Aurora Serverless v1 (deprecado)
+- ⚠️ **NO recomendado**: AWS está deprecando esta versión
+- Problemas de cold start (10-30 segundos)
+
+---
+
+## 🔍 Comparación para TU caso específico
+
+### Escenario realista para Sweet Lab:
+
+| Métrica | Estimación | Neon Free | Neon Launch | AWS RDS Micro | Aurora Serverless v2 |
+|---------|-----------|-----------|-------------|---------------|---------------------|
+| **Almacenamiento** | ~500 MB | ✅ Incluido | ✅ Incluido | $0.05/mes | $0.05/mes |
+| **Horas activas/mes** | ~50-80h | ✅ Incluido | ✅ Incluido | $12-15/mes (24/7) | $87+/mes (24/7) |
+| **Conexiones** | ~100/día | ✅ Incluido | ✅ Incluido | Incluido | Incluido |
+| **Backups** | Automáticos | ⚠️ Manual | ✅ Automático | Manual o $1-2/mes | ✅ Automático |
+| **Configuración** | - | ✅ 0 minutos | ✅ 0 minutos | ❌ 2-4 horas | ❌ 4-8 horas |
+| **Administración/mes** | - | ✅ 0 horas | ✅ 0 horas | ❌ 1-2 horas | ❌ 1-2 horas |
+| **COSTO TOTAL** | - | **$0** | **$19** | **$30-50** | **$100-150** |
+
+---
+
+## 💡 Recomendación Final
+
+### Para tu caso (Sweet Lab), Neon es CLARAMENTE superior:
+
+1. **Costo**: $0 vs $30+ USD/mes = **Ahorras $360+/año**
+
+2. **Simplicidad**: 
+   - Neon: Ya está funcionando, 0 configuración adicional
+   - AWS: Necesitarías 4-8 horas de configuración inicial + aprendizaje
+
+3. **Mantenimiento**:
+   - Neon: 0 horas/mes
+   - AWS: 1-2 horas/mes en parches, backups, monitoreo
+
+4. **Escalabilidad**:
+   - Neon: Automática, pagas solo lo que usas
+   - AWS: Manual, pagas 24/7 estés usando o no
+
+5. **Integración**:
+   - Neon: Integración nativa con Netlify
+   - AWS: Configuración manual, posibles problemas de latencia
+
+---
+
+## 📊 Cuándo considerarías AWS
+
+Solo migrarías a AWS si:
+
+1. **Escala masiva**: > 50,000 requests/día consistentes
+2. **Almacenamiento**: > 50 GB de datos
+3. **Compliance**: Requisitos específicos de regulación/certificación
+4. **Multi-región**: Necesitas replicación geográfica compleja
+5. **Servicios específicos AWS**: Necesitas integración profunda con otros servicios AWS
+
+**Para Sweet Lab, ninguno de estos aplica.**
+
+---
+
+## ✅ Plan de Acción Recomendado
+
+### Corto Plazo (Ahora)
+1. ✅ **Mantente en Neon Free** mientras sea posible
+2. ✅ Monitorea tu uso en el dashboard de Neon
+3. ✅ Configura alertas cuando te acerques a los límites
+
+### Mediano Plazo (Si creces)
+1. Si superas el Free Tier → **Actualiza a Neon Launch ($19/mes)**
+2. Si superas Launch → **Neon Scale ($69/mes)** sigue siendo más barato que AWS
+
+### Largo Plazo (Solo si es necesario)
+1. Solo considera AWS si:
+   - Tus ventas mensuales superan $10,000 USD
+   - Tienes > 100,000 requests/día
+   - Necesitas múltiples regiones geográficas
+
+---
+
+## 📈 Estimación de Costos según Crecimiento
+
+| Etapa del Negocio | Ventas/mes | DB Size | Requests/día | Neon | AWS RDS | Diferencia |
+|-------------------|------------|---------|--------------|------|---------|------------|
+| **Actual** | < $3,000 | < 1 GB | < 500 | **$0** | $35 | Ahorras $35/mes |
+| **Pequeño** | $3,000-10,000 | 1-5 GB | 500-2,000 | **$19** | $45 | Ahorras $26/mes |
+| **Mediano** | $10,000-30,000 | 5-20 GB | 2,000-10,000 | **$69** | $75 | Ahorras $6/mes |
+| **Grande** | > $30,000 | > 20 GB | > 10,000 | **$69-150** | $100-200 | Similar o más caro |
+
+---
+
+## 🎓 Conclusión
+
+**Para Sweet Lab: Neon es 3-10 veces más barato que AWS**, además de ser:
+- Más fácil de usar
+- Más fácil de mantener
+- Mejor integrado con tu stack actual (Netlify)
+- Con mejor escalabilidad automática para tu patrón de uso
+
+**No hay ninguna razón para migrar a AWS en este momento.**
+
+---
+
+## 📞 Preguntas Frecuentes
+
+### ¿Y si Neon cierra o cambia de precios?
+- Puedes exportar tu base de datos en cualquier momento (es PostgreSQL estándar)
+- Migrar a AWS/otro proveedor toma ~1-2 horas
+
+### ¿Qué pasa si supero los límites del Free Tier?
+- Neon te avisa antes de llegar al límite
+- Puedes actualizar a Launch ($19/mes) con un click
+- No hay interrupción del servicio
+
+### ¿AWS es más confiable?
+- Neon tiene 99.95% uptime SLA (en planes pagos)
+- AWS RDS tiene 99.95% uptime SLA
+- **Para tu escala, la diferencia es insignificante**
+
+### ¿Neon es suficientemente rápido?
+- Sí, la latencia de Neon es < 10ms para queries simples
+- El cold start (si usas Free Tier) es < 1 segundo
+- Para tu aplicación, esto es más que suficiente
+
+---
+
+**Última actualización**: Octubre 2025  
+**Fuente de precios**: 
+- Neon: https://neon.tech/pricing
+- AWS RDS: https://aws.amazon.com/rds/pricing/


### PR DESCRIPTION
Create a cost analysis document comparing Neon and AWS for the Sweet Lab project.

The analysis concludes that Neon is significantly more cost-effective (3-10x cheaper) for the project's current scale and usage patterns, recommending continued use of Neon's free or launch tiers over AWS RDS or Aurora Serverless.

---
<a href="https://cursor.com/background-agent?bcId=bc-281573e5-3f5e-457d-b130-d33c60f7bc5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-281573e5-3f5e-457d-b130-d33c60f7bc5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

