### PR TITLE
Implementar sugerencias de búsqueda por secuencia de caracteres

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -5220,8 +5220,8 @@ function updateClientDatalistForQuery(queryRaw) {
     // Rebuild <option> list and only show suggestions when user typed something
     dl.innerHTML = '';
     if (!q) return; // do not show any options until typing begins
-    // Strict prefix match by typed sequence
-    const filtered = list.filter(it => (it.key || '').startsWith(q)).slice(0, 12);
+    // Match typed sequence anywhere in the name
+    const filtered = list.filter(it => (it.key || '').includes(q)).slice(0, 12);
     for (const it of filtered) {
         const opt = document.createElement('option');
         opt.value = it.name;
@@ -5261,8 +5261,8 @@ function updateGlobalClientDatalistForQuery(queryRaw) {
     // Rebuild <option> list and only show suggestions when user typed something
     dl.innerHTML = '';
     if (!q) return; // do not show any options until typing begins
-    // Strict prefix match by typed sequence
-    const filtered = list.filter(it => (it.key || '').startsWith(q)).slice(0, 12);
+    // Match typed sequence anywhere in the name
+    const filtered = list.filter(it => (it.key || '').includes(q)).slice(0, 12);
     for (const it of filtered) {
         const opt = document.createElement('option');
         opt.value = it.name;
@@ -5296,8 +5296,8 @@ function wireGlobalClientAutocompleteForInput(inputEl) {
             return;
         }
         
-        // Filter suggestions
-        const filtered = list.filter(it => (it.key || '').startsWith(q)).slice(0, 12);
+        // Filter suggestions - match typed sequence anywhere in the name
+        const filtered = list.filter(it => (it.key || '').includes(q)).slice(0, 12);
         
         if (filtered.length === 0) {
             dropdown.style.display = 'none';


### PR DESCRIPTION
Update search autocomplete to use `includes()` instead of `startsWith()` to match typed sequences anywhere in the suggestion text.

---
<a href="https://cursor.com/background-agent?bcId=bc-45f9d52f-5dea-48ea-8f59-c47e72ec2085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45f9d52f-5dea-48ea-8f59-c47e72ec2085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

