### PR TITLE
Agregar boton de eliminar a filas de cliente

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -173,7 +173,7 @@ function renderClientDetailTable(rows) {
 	tbody.innerHTML = '';
 	if (!rows || rows.length === 0) {
 		const tr = document.createElement('tr');
-		const td = document.createElement('td'); td.colSpan = 8; td.textContent = 'Sin compras'; td.style.opacity = '0.8';
+		const td = document.createElement('td'); td.colSpan = 9; td.textContent = 'Sin compras'; td.style.opacity = '0.8';
 		tr.appendChild(td); tbody.appendChild(tr); return;
 	}
 	for (const r of rows) {
@@ -260,7 +260,30 @@ function renderClientDetailTable(rows) {
 		const tdNu = document.createElement('td'); tdNu.textContent = r.qty_nute ? String(r.qty_nute) : '';
 		const total = calcRowTotal({ arco: r.qty_arco, melo: r.qty_melo, mara: r.qty_mara, oreo: r.qty_oreo, nute: r.qty_nute });
 		const tdTot = document.createElement('td'); tdTot.textContent = fmtNo.format(total);
-		tr.append(tdPay, tdDate, tdAr, tdMe, tdMa, tdOr, tdNu, tdTot);
+		// Delete button
+		const tdDel = document.createElement('td'); tdDel.style.textAlign = 'center';
+		const delBtn = document.createElement('button');
+		delBtn.className = 'row-delete';
+		delBtn.title = 'Eliminar';
+		delBtn.setAttribute('aria-label', 'Eliminar');
+		delBtn.addEventListener('click', async (e) => {
+			e.stopPropagation();
+			if (!confirm(`¿Estás seguro de eliminar esta compra de "${state._clientDetailName || 'este cliente'}"?`)) return;
+			try {
+				await api('DELETE', `${API.Sales}?id=${encodeURIComponent(r.id)}`);
+				notify.info(`Compra eliminada`);
+				// Reload the client detail view
+				if (state._clientDetailFrom === 'global-search') {
+					await loadGlobalClientDetailRows(state._clientDetailName);
+				} else {
+					await loadClientDetailRows(state._clientDetailName);
+				}
+			} catch (err) {
+				notify.error('Error al eliminar: ' + String(err));
+			}
+		});
+		tdDel.appendChild(delBtn);
+		tr.append(tdPay, tdDate, tdAr, tdMe, tdMa, tdOr, tdNu, tdTot, tdDel);
 		tr.addEventListener('mousedown', () => { tr.classList.add('row-highlight'); setTimeout(() => tr.classList.remove('row-highlight'), 3200); });
 		tbody.appendChild(tr);
 	}

--- a/public/cartera.html
+++ b/public/cartera.html
@@ -58,6 +58,7 @@
 							<th class="col-qty">Oreo</th>
 							<th class="col-qty">Nute</th>
 							<th class="col-total">Total</th>
+							<th></th>
 						</tr>
 					</thead>
 					<tbody id="report-tbody"></tbody>
@@ -74,6 +75,7 @@
 							<td id="t-qo" class="col-qty"></td>
 							<td id="t-qn" class="col-qty"></td>
 							<td id="t-grand" class="col-total"></td>
+							<td></td>
 						</tr>
 					</tfoot>
 				</table>
@@ -105,6 +107,7 @@
 
 		let dataset = [];
 		let sellersList = [];
+		let salesMap = {}; // Maps composite key to sale_id
 		let sortColumn = null;
 		let sortDirection = 'desc'; // 'asc' or 'desc'
 
@@ -117,6 +120,18 @@
                 pm === 'jorgebank' ? 'JorgeBank' : '-';
         }
 		async function fetchJSON(u){ const r = await fetch(u); if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }
+		async function deleteSale(saleId, clientName) {
+			if (!confirm(`¿Estás seguro de eliminar la venta de "${clientName || 'este cliente'}"?`)) return;
+			try {
+				const url = withActor(`/api/sales?id=${saleId}`);
+				const r = await fetch(url, { method: 'DELETE' });
+				if (!r.ok) throw new Error(`HTTP ${r.status}`);
+				// Reload data after deletion
+				await load();
+			} catch (err) {
+				alert('Error al eliminar: ' + String(err));
+			}
+		}
 		function withActor(url){
 			try { const u = new URL(url, location.origin); if (actor) u.searchParams.set('actor', actor); return u.pathname + (u.search || ''); }
 			catch { return url + (url.includes('?') ? `&actor=${encodeURIComponent(actor)}` : `?actor=${encodeURIComponent(actor)}`); }
@@ -241,9 +256,19 @@
 					<td>${r.qma||''}</td>
 					<td>${r.qo||''}</td>
 					<td>${r.qn||''}</td>
-					<td class="col-total">${r.tot||''}</td>`;
+					<td class="col-total">${r.tot||''}</td>
+					<td style="text-align:center;"><button class="delete-btn" data-sale-id="${r.saleId||''}" data-client-name="${(r.client_name||'').replace(/"/g,'&quot;')}" title="Eliminar" style="background:none; border:none; cursor:pointer; font-size:18px; color:#e74c3c; padding:4px 8px;">🗑️</button></td>`;
 				tbody.appendChild(tr);
 				tQa += r.qa||0; tQm += r.qm||0; tQma += r.qma||0; tQo += r.qo||0; tQn += r.qn||0; tGrand += r.tot||0;
+			}
+			// Attach delete event listeners
+			const deleteBtns = tbody.querySelectorAll('.delete-btn');
+			for (const btn of deleteBtns) {
+				btn.addEventListener('click', () => {
+					const saleId = btn.getAttribute('data-sale-id');
+					const clientName = btn.getAttribute('data-client-name');
+					if (saleId) deleteSale(saleId, clientName);
+				});
 			}
 			tQaEl.textContent = tQa || '';
 			tQmEl.textContent = tQm || '';
@@ -370,7 +395,8 @@
 							client_name: r.client_name || '',
 							pay_method: pm,
 							is_paid: !!r.is_paid,
-							qa, qm, qma, qo, qn, tot
+							qa, qm, qma, qo, qn, tot,
+							saleId: r.id
 						});
 					}
 				} catch {}

--- a/public/cartera.html
+++ b/public/cartera.html
@@ -257,7 +257,7 @@
 					<td>${r.qo||''}</td>
 					<td>${r.qn||''}</td>
 					<td class="col-total">${r.tot||''}</td>
-					<td style="text-align:center;"><button class="delete-btn" data-sale-id="${r.saleId||''}" data-client-name="${(r.client_name||'').replace(/"/g,'&quot;')}" title="Eliminar" style="background:none; border:none; cursor:pointer; font-size:18px; color:#e74c3c; padding:4px 8px;">🗑️</button></td>`;
+					<td style="text-align:center;"><button class="row-delete delete-btn" data-sale-id="${r.saleId||''}" data-client-name="${(r.client_name||'').replace(/"/g,'&quot;')}" title="Eliminar"></button></td>`;
 				tbody.appendChild(tr);
 				tQa += r.qa||0; tQm += r.qm||0; tQma += r.qma||0; tQo += r.qo||0; tQn += r.qn||0; tGrand += r.tot||0;
 			}

--- a/public/index.html
+++ b/public/index.html
@@ -342,6 +342,7 @@
 									<th class="col-oreo">Oreo</th>
 									<th class="col-nute">Nute</th>
 									<th class="col-total">Total</th>
+									<th></th>
 								</tr>
 							</thead>
 							<tbody id="client-detail-tbody"></tbody>


### PR DESCRIPTION
Add a red trash can icon button to each row in the client page table to allow users to delete a sale.

This PR introduces a delete button with a trash can icon at the end of each row in `cartera.html`. Clicking the button prompts a confirmation and then calls the `/api/sales` DELETE endpoint with the corresponding `saleId` to remove the sale, refreshing the table upon success.

---
<a href="https://cursor.com/background-agent?bcId=bc-f01ad558-e792-4c66-890b-5ec80c530324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f01ad558-e792-4c66-890b-5ec80c530324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

