### PR TITLE
Mark notifications as read for superadmin

### DIFF
--- a/netlify/functions/notifications.js
+++ b/netlify/functions/notifications.js
@@ -8,7 +8,39 @@ export async function handler(event) {
 	try {
 		await ensureSchema();
 		if (event.httpMethod === 'OPTIONS') return json({ ok: true });
+		
+		// Handle PATCH request to mark notification as read/unread
+		if (event.httpMethod === 'PATCH') {
+			const body = JSON.parse(event.body || '{}');
+			const notificationId = Number(body.id);
+			const isRead = body.is_read;
+			
+			if (!notificationId) {
+				return json({ error: 'ID de notificación requerido' }, 400);
+			}
+			
+			if (typeof isRead !== 'boolean') {
+				return json({ error: 'is_read debe ser un booleano' }, 400);
+			}
+			
+			// Update read_at: set to current timestamp if marking as read, null if marking as unread
+			const readAt = isRead ? new Date() : null;
+			const [updated] = await sql`
+				UPDATE notifications 
+				SET read_at = ${readAt}
+				WHERE id = ${notificationId}
+				RETURNING id, type, seller_id, sale_id, sale_day_id, message, actor_name, icon_url, pay_method, created_at, read_at
+			`;
+			
+			if (!updated) {
+				return json({ error: 'Notificación no encontrada' }, 404);
+			}
+			
+			return json(updated);
+		}
+		
 		if (event.httpMethod !== 'GET') return json({ error: 'Método no permitido' }, 405);
+		
 		const params = new URLSearchParams(event.rawQuery || (event.queryStringParameters ? new URLSearchParams(event.queryStringParameters).toString() : ''));
 		const afterId = Number(params.get('after_id')) || 0;
 		const beforeId = Number(params.get('before_id')) || 0;
@@ -17,13 +49,13 @@ export async function handler(event) {
 		const limitParam = Math.max(1, Math.min(200, limitParamRaw || 100));
 		let rows;
 		if (afterId) {
-			rows = await sql`SELECT id, type, seller_id, sale_id, sale_day_id, message, actor_name, icon_url, pay_method, created_at FROM notifications WHERE id > ${afterId} ORDER BY id ASC LIMIT ${limitParam}`;
+			rows = await sql`SELECT id, type, seller_id, sale_id, sale_day_id, message, actor_name, icon_url, pay_method, created_at, read_at FROM notifications WHERE id > ${afterId} ORDER BY id ASC LIMIT ${limitParam}`;
 		} else if (beforeId) {
-			rows = await sql`SELECT id, type, seller_id, sale_id, sale_day_id, message, actor_name, icon_url, pay_method, created_at FROM notifications WHERE id < ${beforeId} ORDER BY id DESC LIMIT ${limitParam}`;
+			rows = await sql`SELECT id, type, seller_id, sale_id, sale_day_id, message, actor_name, icon_url, pay_method, created_at, read_at FROM notifications WHERE id < ${beforeId} ORDER BY id DESC LIMIT ${limitParam}`;
 		} else if (sinceParam) {
-			rows = await sql`SELECT id, type, seller_id, sale_id, sale_day_id, message, actor_name, icon_url, pay_method, created_at FROM notifications WHERE created_at > ${new Date(sinceParam)} ORDER BY created_at ASC, id ASC LIMIT ${limitParam}`;
+			rows = await sql`SELECT id, type, seller_id, sale_id, sale_day_id, message, actor_name, icon_url, pay_method, created_at, read_at FROM notifications WHERE created_at > ${new Date(sinceParam)} ORDER BY created_at ASC, id ASC LIMIT ${limitParam}`;
 		} else {
-			rows = await sql`SELECT id, type, seller_id, sale_id, sale_day_id, message, actor_name, icon_url, pay_method, created_at FROM notifications ORDER BY id DESC LIMIT ${limitParam}`;
+			rows = await sql`SELECT id, type, seller_id, sale_id, sale_day_id, message, actor_name, icon_url, pay_method, created_at, read_at FROM notifications ORDER BY id DESC LIMIT ${limitParam}`;
 		}
 		return json(rows);
 	} catch (e) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -181,6 +181,35 @@
 .notif-del:hover { color: var(--danger); background: rgba(239, 68, 68, 0.06); border-color: rgba(239, 68, 68, 0.15); }
 .notif-del:active { transform: scale(0.96); }
 
+/* Checkbox for read/unread status (superadmin only) */
+.notif-checkbox {
+	width: 18px;
+	height: 18px;
+	cursor: pointer;
+	margin: 2px 8px 0 0;
+	accent-color: var(--primary);
+	flex-shrink: 0;
+}
+
+/* Read notification styling */
+.notif-item.notif-read {
+	opacity: 0.6;
+	background: rgba(0, 0, 0, 0.02);
+}
+
+[data-theme="dark"] .notif-item.notif-read {
+	opacity: 0.5;
+	background: rgba(255, 255, 255, 0.02);
+}
+
+.notif-item.notif-read:hover {
+	opacity: 0.75;
+}
+
+[data-theme="dark"] .notif-item.notif-read:hover {
+	opacity: 0.65;
+}
+
 /* Dark: medium-dark headers and neutral buttons */
 [data-theme="dark"] .app-header,
 [data-theme="dark"] .sellers-panel .panel-header,


### PR DESCRIPTION
Add functionality for superadmins to mark notifications as read/unread to facilitate tracking.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e250768-873b-4890-997d-79822d229991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e250768-873b-4890-997d-79822d229991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

