### PR TITLE
Remove dotted underlines from accounting fields

### DIFF
--- a/public/accounting.html
+++ b/public/accounting.html
@@ -20,15 +20,12 @@
 		/* Celdas editables */
 		.editable { 
 			cursor: pointer; 
-			text-decoration: underline dotted; 
-			text-underline-offset: 2px;
 			transition: background-color 0.2s ease, transform 0.1s ease;
 			padding: 4px 8px;
 			border-radius: 4px;
 		}
 		.editable:hover {
 			background-color: rgba(244, 166, 183, 0.15);
-			text-decoration-color: var(--primary);
 			transform: scale(1.02);
 		}
 		.editable:active {


### PR DESCRIPTION
Remove dotted underlines from editable fields on the accounting page.

---
<a href="https://cursor.com/background-agent?bcId=bc-43f868f9-a28b-472a-a0e8-df256eb8805b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43f868f9-a28b-472a-a0e8-df256eb8805b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

