### PR TITLE
Fix payment date and method saving bug

### DIFF
--- a/netlify/functions/_db.js
+++ b/netlify/functions/_db.js
@@ -188,6 +188,7 @@ export async function ensureSchema() {
 		qty_nute INTEGER NOT NULL DEFAULT 0,
 		is_paid BOOLEAN NOT NULL DEFAULT false,
 		pay_method TEXT,
+		pay_date DATE,
 		comment_text TEXT DEFAULT '',
 		total_cents INTEGER NOT NULL DEFAULT 0,
 		created_at TIMESTAMPTZ DEFAULT now()
@@ -211,6 +212,12 @@ export async function ensureSchema() {
 			WHERE table_name = 'sales' AND column_name = 'pay_method'
 		) THEN
 			ALTER TABLE sales ADD COLUMN pay_method TEXT;
+		END IF;
+		IF NOT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'sales' AND column_name = 'pay_date'
+		) THEN
+			ALTER TABLE sales ADD COLUMN pay_date DATE;
 		END IF;
 		IF NOT EXISTS (
 			SELECT 1 FROM information_schema.columns

--- a/netlify/functions/sales.js
+++ b/netlify/functions/sales.js
@@ -54,7 +54,7 @@ export async function handler(event) {
 							// Admin can see all sales - optimized query with minimal data
 							rows = await sql`
 								SELECT s.id, s.seller_id, s.sale_day_id, s.client_name, s.qty_arco, s.qty_melo, 
-								       s.qty_mara, s.qty_oreo, s.qty_nute, s.is_paid, s.pay_method, 
+								       s.qty_mara, s.qty_oreo, s.qty_nute, s.is_paid, s.pay_method, s.pay_date,
 								       s.total_cents,
 								       sd.day AS sale_day,
 								       se.name AS seller_name
@@ -68,7 +68,7 @@ export async function handler(event) {
 							// Non-admin can only see their own sales or sales they have permission to view
 							rows = await sql`
 								SELECT s.id, s.seller_id, s.sale_day_id, s.client_name, s.qty_arco, s.qty_melo, 
-								       s.qty_mara, s.qty_oreo, s.qty_nute, s.is_paid, s.pay_method, 
+								       s.qty_mara, s.qty_oreo, s.qty_nute, s.is_paid, s.pay_method, s.pay_date,
 								       s.total_cents,
 								       sd.day AS sale_day,
 								       se.name AS seller_name
@@ -190,9 +190,9 @@ export async function handler(event) {
 				} catch {}
 				let rows;
 				if (saleDayId) {
-					rows = await sql`SELECT id, seller_id, sale_day_id, client_name, qty_arco, qty_melo, qty_mara, qty_oreo, qty_nute, is_paid, pay_method, comment_text, total_cents, created_at FROM sales WHERE seller_id = ${sellerId} AND sale_day_id=${saleDayId} ORDER BY created_at DESC, id DESC`;
+					rows = await sql`SELECT id, seller_id, sale_day_id, client_name, qty_arco, qty_melo, qty_mara, qty_oreo, qty_nute, is_paid, pay_method, pay_date, comment_text, total_cents, created_at FROM sales WHERE seller_id = ${sellerId} AND sale_day_id=${saleDayId} ORDER BY created_at DESC, id DESC`;
 				} else {
-					rows = await sql`SELECT id, seller_id, sale_day_id, client_name, qty_arco, qty_melo, qty_mara, qty_oreo, qty_nute, is_paid, pay_method, comment_text, total_cents, created_at FROM sales WHERE seller_id = ${sellerId} ORDER BY created_at DESC, id DESC`;
+					rows = await sql`SELECT id, seller_id, sale_day_id, client_name, qty_arco, qty_melo, qty_mara, qty_oreo, qty_nute, is_paid, pay_method, pay_date, comment_text, total_cents, created_at FROM sales WHERE seller_id = ${sellerId} ORDER BY created_at DESC, id DESC`;
 				}
 				
 				// Enhance with sale_items data for each sale
@@ -233,7 +233,7 @@ export async function handler(event) {
 					const iso = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())).toISOString().slice(0,10);
 					saleDayId = await getOrCreateDayId(sellerId, iso);
 				}
-				const [row] = await sql`INSERT INTO sales (seller_id, sale_day_id) VALUES (${sellerId}, ${saleDayId}) RETURNING id, seller_id, sale_day_id, client_name, qty_arco, qty_melo, qty_mara, qty_oreo, qty_nute, is_paid, pay_method, comment_text, total_cents, created_at`;
+				const [row] = await sql`INSERT INTO sales (seller_id, sale_day_id) VALUES (${sellerId}, ${saleDayId}) RETURNING id, seller_id, sale_day_id, client_name, qty_arco, qty_melo, qty_mara, qty_oreo, qty_nute, is_paid, pay_method, pay_date, comment_text, total_cents, created_at`;
 				// Emit a notification for new sale with identifiers for deep linking
 				try {
 					const msg = `${row.client_name || 'Cliente'} nuevo pedido`;
@@ -245,7 +245,7 @@ export async function handler(event) {
 				const data = JSON.parse(event.body || '{}');
 				const id = Number(data.id);
 				if (!id) return json({ error: 'id requerido' }, 400);
-				const current = (await sql`SELECT client_name, qty_arco, qty_melo, qty_mara, qty_oreo, qty_nute, is_paid, pay_method, comment_text, created_at FROM sales WHERE id=${id}`)[0] || {};
+				const current = (await sql`SELECT client_name, qty_arco, qty_melo, qty_mara, qty_oreo, qty_nute, is_paid, pay_method, pay_date, comment_text, created_at FROM sales WHERE id=${id}`)[0] || {};
 				const createdAt = current.created_at ? new Date(current.created_at) : null;
 				const withinGrace = createdAt ? ((new Date()) - createdAt) < 120000 : false; // 2 minutes
 				const client = (data.client_name ?? '').toString();
@@ -262,9 +262,10 @@ export async function handler(event) {
 				const qn = Number(data.qty_nute ?? 0) || 0;
 				const paid = (data.is_paid === true || data.is_paid === 'true') ? true : (data.is_paid === false || data.is_paid === 'false') ? false : current.is_paid;
 				const payMethod = (Object.prototype.hasOwnProperty.call(data, 'pay_method')) ? (data.pay_method ?? null) : current.pay_method;
+				const payDate = (Object.prototype.hasOwnProperty.call(data, 'pay_date')) ? (data.pay_date ?? null) : current.pay_date;
 				
 				// Update sale basic info
-				await sql`UPDATE sales SET client_name=${client}, comment_text=${comment}, qty_arco=${qa}, qty_melo=${qm}, qty_mara=${qma}, qty_oreo=${qo}, qty_nute=${qn}, is_paid=${paid}, pay_method=${payMethod} WHERE id=${id}`;
+				await sql`UPDATE sales SET client_name=${client}, comment_text=${comment}, qty_arco=${qa}, qty_melo=${qm}, qty_mara=${qma}, qty_oreo=${qo}, qty_nute=${qn}, is_paid=${paid}, pay_method=${payMethod}, pay_date=${payDate} WHERE id=${id}`;
 				
 				// If items are provided, update sale_items table
 				if (items !== null) {


### PR DESCRIPTION
Persist payment date and method for sales to ensure selections are saved and displayed correctly after navigation.

The previous implementation only stored payment date and method in the client's memory, causing the selected date and method to disappear when the user reopened the payment dialog or navigated away from the sales table. This PR introduces a `pay_date` column in the database, updates the API to handle its persistence, and modifies the frontend to save and retrieve this information from the backend. Additionally, the payment method comparison in the frontend was corrected to use the `value` attribute for accurate selection display.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3906f05-ae66-42cc-9321-e6f6f39cd347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3906f05-ae66-42cc-9321-e6f6f39cd347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

