### PR TITLE
Fix payment date and method saving bug

### DIFF
--- a/netlify/functions/_db.js
+++ b/netlify/functions/_db.js
@@ -224,6 +224,12 @@ export async function ensureSchema() {
 		) THEN
 			ALTER TABLE sales ADD COLUMN qty_nute INTEGER NOT NULL DEFAULT 0;
 		END IF;
+		IF NOT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'sales' AND column_name = 'payment_date'
+		) THEN
+			ALTER TABLE sales ADD COLUMN payment_date DATE;
+		END IF;
 	END $$;`;
 	await sql`CREATE TABLE IF NOT EXISTS change_logs (
 		id SERIAL PRIMARY KEY,


### PR DESCRIPTION
Add `payment_date` column to the `sales` table to enable saving payment dates.

This fixes a bug where the payment date selected in the sales table action bar was not being persisted.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce64fc5e-4cf9-4520-b3a8-89128cf26627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce64fc5e-4cf9-4520-b3a8-89128cf26627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

