### PR TITLE
Fix portfolio payment column display

### DIFF
--- a/public/cartera.html
+++ b/public/cartera.html
@@ -533,14 +533,7 @@
 						const pm = (r.pay_method || '').toString();
 						const ps = (r.payment_source || '').toString();
 						const pd = r.payment_date ? String(r.payment_date).slice(0, 10) : '';
-						const unpaid = r.is_paid !== true;
-                        // Allow sale if:
-                        // 1. It has a payment date (regardless of paid status), OR
-                        // 2. It's unpaid AND has a valid payment method or source
-                        const hasPaymentDate = pd !== '';
-                        const hasPayMethod = (pm === '' || pm === 'efectivo' || pm === 'transf' || pm === 'marce' || pm === 'jorge' || pm === 'jorgebank');
-                        const hasPaySource = (ps !== '');
-						if (!(hasPaymentDate || (unpaid && (hasPayMethod || hasPaySource)))) continue;
+						// Include ALL sales - no filtering at data load time
 						
 						// Support both formats: old (qty_*) and new (items array)
 						let qa = r.qty_arco || 0;


### PR DESCRIPTION
Refactor the cartera page to separate payment method and source into distinct columns and ensure all sales, including dessert quantities, are correctly displayed.

The previous implementation merged `pay_method` and `payment_source` into a single 'Pago' column, causing confusion. More importantly, the filtering logic inadvertently excluded sales that had a `payment_source` but not a recognized `pay_method`, leading to incomplete data (e.g., missing dessert quantities) for those entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-62333af9-e583-4f14-919d-a55f0dd6856b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62333af9-e583-4f14-919d-a55f0dd6856b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

