### PR TITLE
Fix cartera sales data errors

### DIFF
--- a/public/cartera.html
+++ b/public/cartera.html
@@ -130,6 +130,9 @@
 		let sortColumn = null;
 		let sortDirection = 'desc'; // 'asc' or 'desc'
 
+		// Precio de venta por postre (alineado con el backend)
+		const PRICES = { arco: 8500, melo: 9500, mara: 10500, oreo: 10500, nute: 13000 };
+
         function payLabel(pm){
             const lower = (pm || '').toString().toLowerCase();
             if (lower === 'efectivo aleja' || lower === 'efectivo_aleja') return 'Efectivo Aleja';
@@ -555,8 +558,28 @@
 								else if (code === 'nute') qn += qty;
 							}
 						}
-						
-                        const tot = Number(r.total_cents || 0) || 0;
+
+						// Recalcular total de forma resiliente (items -> cantidades * precios -> total_cents)
+						let totCalc = 0;
+						if (Array.isArray(r.items) && r.items.length > 0) {
+							for (const item of r.items) {
+								const code = (item.short_code || '').toLowerCase();
+								const qty = Number(item.quantity || 0) || 0;
+								let price = Number(item.unit_price || 0) || 0;
+								if (!price) {
+									if (code === 'arco') price = PRICES.arco;
+									else if (code === 'melo') price = PRICES.melo;
+									else if (code === 'mara') price = PRICES.mara;
+									else if (code === 'oreo') price = PRICES.oreo;
+									else if (code === 'nute') price = PRICES.nute;
+								}
+								totCalc += qty * price;
+							}
+						} else {
+							totCalc = (qa * PRICES.arco) + (qm * PRICES.melo) + (qma * PRICES.mara) + (qo * PRICES.oreo) + (qn * PRICES.nute);
+						}
+						const totDb = Number(r.total_cents || 0) || 0;
+						const tot = totCalc > 0 ? totCalc : totDb;
 						dataset.push({
 							date: String(day.day).slice(0,10),
 							sellerName: seller.name || '',


### PR DESCRIPTION
Recalculate sales report totals in `cartera.html` to fix discrepancies caused by incorrect `total_cents` values.

The previous `total_cents` field in sales records could be outdated or incorrect, leading to wrong totals in the cartera report (e.g., 2 Nute items showing 13.000 instead of 26.000). This change ensures the total is reliably calculated from `items` (quantity x unit_price, falling back to fixed prices if `unit_price` is missing) or, if no `items` are present, from `qty_*` fields using predefined prices. The `total_cents` from the database is used only as a last resort if the calculation yields zero.

---
<a href="https://cursor.com/background-agent?bcId=bc-05fe094e-ae00-4f18-85d2-0dd672ba76c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05fe094e-ae00-4f18-85d2-0dd672ba76c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

