### PR TITLE
feat: popover de nuevo pedido dinamico y compacto (shorterPopup)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2782,7 +2782,7 @@ function openNewSalePopover(anchorX, anchorY) {
 
 			grid.appendChild(left);
 			grid.appendChild(right);
-			return { chipM, chipC };
+			return { left, right, chipM, chipC };
 		}
 
 		const clientInput = document.createElement('input');
@@ -2793,9 +2793,22 @@ function openNewSalePopover(anchorX, anchorY) {
 		attachClientSuggestionsPopover(clientInput);
 		appendRow('Cliente', clientInput);
 
+		// Compute active dessert IDs (based on visibleDesserts, fallback to active store desserts)
+		let defaultActiveIds = new Set((state.visibleDesserts || []).map(d => d.id));
+		if (defaultActiveIds.size === 0) {
+			defaultActiveIds = new Set(
+				(state.desserts || [])
+					.filter(d => d.is_active)
+					.map(d => d.id)
+			);
+		}
+
 		// Dessert rows (dynamic from state.desserts)
 		const qtyInputs = {};
 		const priceInputs = {};
+		let hiddenCount = 0;
+		const hiddenRows = [];
+
 		for (const d of state.desserts) {
 			const input = document.createElement('input');
 			input.type = 'number';
@@ -2818,7 +2831,29 @@ function openNewSalePopover(anchorX, anchorY) {
 			priceInput.title = 'Precio unitario promocional manual (vacío para usar normal)';
 			priceInputs[d.short_code] = priceInput;
 
-			appendDessertRow(d, input, priceInput);
+			const rowCells = appendDessertRow(d, input, priceInput);
+
+			if (!defaultActiveIds.has(d.id)) {
+				rowCells.left.classList.add('hidden-dessert-cell');
+				rowCells.right.classList.add('hidden-dessert-cell');
+				hiddenRows.push(rowCells.left, rowCells.right);
+				hiddenCount++;
+			}
+		}
+
+		if (hiddenCount > 0) {
+			const showMoreBtn = document.createElement('button');
+			showMoreBtn.type = 'button';
+			showMoreBtn.className = 'show-more-desserts-btn';
+			showMoreBtn.textContent = '✨ Mostrar más postres';
+			showMoreBtn.addEventListener('click', (e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				hiddenRows.forEach(cell => cell.classList.remove('hidden-dessert-cell'));
+				showMoreBtn.remove();
+				clampWithinViewport();
+			});
+			grid.appendChild(showMoreBtn);
 		}
 
 		const actions = document.createElement('div');
@@ -3124,7 +3159,7 @@ function openEditSalePopover(saleId, anchorX, anchorY, onCloseCallback) {
 
 			grid.appendChild(left);
 			grid.appendChild(right);
-			return { chipM, chipC };
+			return { left, right, chipM, chipC };
 		}
 
 		// Client row - prefilled
@@ -3137,9 +3172,39 @@ function openEditSalePopover(saleId, anchorX, anchorY, onCloseCallback) {
 		attachClientSuggestionsPopover(clientInput);
 		appendRow('Cliente', clientInput);
 
+		// Compute active dessert IDs (based on visibleDesserts, fallback to active store desserts)
+		let defaultActiveIds = new Set((state.visibleDesserts || []).map(d => d.id));
+		if (defaultActiveIds.size === 0) {
+			defaultActiveIds = new Set(
+				(state.desserts || [])
+					.filter(d => d.is_active)
+					.map(d => d.id)
+			);
+		}
+		// Always show any dessert that has a positive quantity in this sale
+		if (sale) {
+			if (Array.isArray(sale.items) && sale.items.length > 0) {
+				sale.items.forEach(item => {
+					if (Number(item.quantity || 0) > 0) {
+						defaultActiveIds.add(item.dessert_id);
+					}
+				});
+			} else {
+				for (const d of state.desserts) {
+					const qty = Number(sale[`qty_${d.short_code}`] || 0);
+					if (qty > 0) {
+						defaultActiveIds.add(d.id);
+					}
+				}
+			}
+		}
+
 		// Dessert rows (dynamic from state.desserts) - prefilled
 		const qtyInputs = {};
 		const priceInputs = {};
+		let hiddenCount = 0;
+		const hiddenRows = [];
+
 		for (const d of state.desserts) {
 			const input = document.createElement('input');
 			input.type = 'number';
@@ -3196,6 +3261,28 @@ function openEditSalePopover(saleId, anchorX, anchorY, onCloseCallback) {
 					priceInput.dataset.specialPricingType = '';
 				}
 			}
+
+			if (!defaultActiveIds.has(d.id)) {
+				chips.left.classList.add('hidden-dessert-cell');
+				chips.right.classList.add('hidden-dessert-cell');
+				hiddenRows.push(chips.left, chips.right);
+				hiddenCount++;
+			}
+		}
+
+		if (hiddenCount > 0) {
+			const showMoreBtn = document.createElement('button');
+			showMoreBtn.type = 'button';
+			showMoreBtn.className = 'show-more-desserts-btn';
+			showMoreBtn.textContent = '✨ Mostrar más postres';
+			showMoreBtn.addEventListener('click', (e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				hiddenRows.forEach(cell => cell.classList.remove('hidden-dessert-cell'));
+				showMoreBtn.remove();
+				clampWithinViewport();
+			});
+			grid.appendChild(showMoreBtn);
 		}
 
 		const actions = document.createElement('div');
@@ -3387,6 +3474,7 @@ async function openNewSalePopoverWithDate(anchorX, anchorY, prefilledClientName)
 			});
 			grid.appendChild(left);
 			grid.appendChild(right);
+			return { left, right };
 		}
 
 		// Date selection row
@@ -3850,8 +3938,21 @@ async function openNewSalePopoverWithDate(anchorX, anchorY, prefilledClientName)
 		attachClientSuggestionsPopover(clientInput);
 		appendRow('Cliente', clientInput);
 
+		// Compute active dessert IDs (based on visibleDesserts, fallback to active store desserts)
+		let defaultActiveIds = new Set((state.visibleDesserts || []).map(d => d.id));
+		if (defaultActiveIds.size === 0) {
+			defaultActiveIds = new Set(
+				(state.desserts || [])
+					.filter(d => d.is_active)
+					.map(d => d.id)
+			);
+		}
+
 		// Dessert rows (dynamic from state.desserts)
 		const qtyInputs = {};
+		let hiddenCount = 0;
+		const hiddenRows = [];
+
 		for (const d of state.desserts) {
 			const input = document.createElement('input');
 			input.type = 'number';
@@ -3862,7 +3963,29 @@ async function openNewSalePopoverWithDate(anchorX, anchorY, prefilledClientName)
 			input.className = 'input-cell input-qty';
 			input.dataset.dessertId = d.id;
 			qtyInputs[d.short_code] = input;
-			appendRow(d.name, input);
+			const rowCells = appendRow(d.name, input);
+
+			if (!defaultActiveIds.has(d.id)) {
+				rowCells.left.classList.add('hidden-dessert-cell');
+				rowCells.right.classList.add('hidden-dessert-cell');
+				hiddenRows.push(rowCells.left, rowCells.right);
+				hiddenCount++;
+			}
+		}
+
+		if (hiddenCount > 0) {
+			const showMoreBtn = document.createElement('button');
+			showMoreBtn.type = 'button';
+			showMoreBtn.className = 'show-more-desserts-btn';
+			showMoreBtn.textContent = '✨ Mostrar más postres';
+			showMoreBtn.addEventListener('click', (e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				hiddenRows.forEach(cell => cell.classList.remove('hidden-dessert-cell'));
+				showMoreBtn.remove();
+				clampWithinViewport();
+			});
+			grid.appendChild(showMoreBtn);
 		}
 
 		const actions = document.createElement('div');

--- a/public/store-transactions.js
+++ b/public/store-transactions.js
@@ -42,8 +42,7 @@ function updateCartUI() {
             if (separator) separator.style.display = 'none';
             internalCheckoutContainer.style.display = 'flex';
             document.getElementById('internal-checkout-btn').style.display = 'block';
-            loadSellerClients();
-            loadSellerDays();
+            updateDateSelectorUI();
         } else {
             if (waBtn) waBtn.style.display = 'block';
             if (uploadBtn) uploadBtn.style.display = 'block';
@@ -86,6 +85,8 @@ function updateAuthUI() {
             iframe.title = 'Registro de Ventas';
             embedContainer.appendChild(iframe);
         }
+        loadSellerClients();
+        loadSellerDays();
     } else if (storeAuthUser && storeAuthUser.username) {
         // Logged in but no seller selected yet
         storeAuthBtn.textContent = 'Seleccionar Vendedor';
@@ -205,14 +206,32 @@ async function loadSellerDays() {
 function updateDateSelectorUI() {
     const container = document.getElementById('store-order-date-container');
     if (!container) return;
-    container.innerHTML = '';
     
     if (storeSellerDays.length <= 1) {
         container.style.display = 'none';
+        container.innerHTML = '';
         storeSelectedDayId = storeSellerDays[0] ? storeSellerDays[0].id : null;
         return;
     }
 
+    // Optimization: If the cards are already rendered for the current list of days, do not rebuild.
+    // This preserves selection state and prevents layout flicker.
+    const existingCards = container.querySelectorAll('.store-date-card');
+    if (existingCards.length === storeSellerDays.length) {
+        let matchesAll = true;
+        existingCards.forEach((card, idx) => {
+            if (card.dataset.dayId !== String(storeSellerDays[idx].id)) {
+                matchesAll = false;
+            }
+        });
+        if (matchesAll) {
+            container.style.display = 'flex';
+            return;
+        }
+    }
+
+    container.innerHTML = '';
+    
     // Set first day as default selected
     storeSelectedDayId = storeSellerDays[0].id;
 
@@ -375,6 +394,8 @@ function setSeller(seller) {
     safeLS.setItem('storeActiveSeller', JSON.stringify(seller));
     document.getElementById('store-seller-modal').style.display = 'none';
     updateAuthUI();
+    loadSellerClients();
+    loadSellerDays();
     updateCartUI();
 }
 

--- a/public/store-transactions.js
+++ b/public/store-transactions.js
@@ -167,17 +167,22 @@ async function loadSellerClients() {
 }
 
 let storeSellerDays = [];
+let storeSelectedDayId = null;
 
-function formatStoreDayLabel(input) {
-    if (!input) return 'Fecha';
+function formatStoreDayCardParts(input) {
+    if (!input) return { weekday: 'Fecha', dateString: '' };
     let iso = String(input);
     if (/^\d{4}-\d{2}-\d{2}T/.test(iso)) iso = iso.slice(0, 10);
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) return String(input);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) return { weekday: String(input), dateString: '' };
     const d = new Date(iso + 'T00:00:00Z');
-    if (isNaN(d.getTime())) return iso;
+    if (isNaN(d.getTime())) return { weekday: iso, dateString: '' };
     const weekdays = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
     const months = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'];
-    return `${weekdays[d.getUTCDay()]} ${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
+    
+    return {
+        weekday: weekdays[d.getUTCDay()],
+        dateString: `${d.getUTCDate()} de ${months[d.getUTCMonth()]}`
+    };
 }
 
 async function loadSellerDays() {
@@ -198,22 +203,53 @@ async function loadSellerDays() {
 }
 
 function updateDateSelectorUI() {
-    const select = document.getElementById('store-order-date-select');
-    if (!select) return;
-    select.innerHTML = '';
+    const container = document.getElementById('store-order-date-container');
+    if (!container) return;
+    container.innerHTML = '';
     
     if (storeSellerDays.length <= 1) {
-        select.style.display = 'none';
+        container.style.display = 'none';
+        storeSelectedDayId = storeSellerDays[0] ? storeSellerDays[0].id : null;
         return;
     }
 
-    storeSellerDays.forEach(d => {
-        const opt = document.createElement('option');
-        opt.value = d.id;
-        opt.textContent = formatStoreDayLabel(d.day);
-        select.appendChild(opt);
+    // Set first day as default selected
+    storeSelectedDayId = storeSellerDays[0].id;
+
+    storeSellerDays.forEach((d, idx) => {
+        const card = document.createElement('div');
+        card.className = `store-date-card ${idx === 0 ? 'active' : ''}`;
+        card.dataset.dayId = d.id;
+
+        const parts = formatStoreDayCardParts(d.day);
+
+        const weekdayEl = document.createElement('span');
+        weekdayEl.className = 'store-date-card-day';
+        weekdayEl.textContent = parts.weekday;
+
+        const dateEl = document.createElement('span');
+        dateEl.className = 'store-date-card-date';
+        dateEl.textContent = parts.dateString;
+
+        card.appendChild(weekdayEl);
+        if (parts.dateString) card.appendChild(dateEl);
+
+        card.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            
+            // Update selected ID
+            storeSelectedDayId = d.id;
+            
+            // Toggle active classes
+            container.querySelectorAll('.store-date-card').forEach(c => c.classList.remove('active'));
+            card.classList.add('active');
+        });
+
+        container.appendChild(card);
     });
-    select.style.display = 'block';
+    
+    container.style.display = 'flex';
 }
 
 function setupClientAutocomplete() {
@@ -380,9 +416,6 @@ async function executeCheckout(customerName) {
     const newClientWhatsApp = document.getElementById('new-client-whatsapp');
     const whatsappValue = (newClientWhatsApp ? newClientWhatsApp.value : '') || customerNameInput.dataset.whatsapp || '';
     
-    const dateSelect = document.getElementById('store-order-date-select');
-    const selectedDayId = (dateSelect && dateSelect.style.display !== 'none') ? dateSelect.value : null;
-
     const saleItems = [];
     for (const productId in cart) {
         saleItems.push({ 
@@ -401,7 +434,7 @@ async function executeCheckout(customerName) {
         seller: storeActiveSeller,
         user: storeAuthUser,
         timestamp: new Date().toISOString(),
-        sale_day_id: selectedDayId
+        sale_day_id: storeSelectedDayId
     };
 
     // 1. Queue immediately

--- a/public/store-transactions.js
+++ b/public/store-transactions.js
@@ -43,6 +43,7 @@ function updateCartUI() {
             internalCheckoutContainer.style.display = 'flex';
             document.getElementById('internal-checkout-btn').style.display = 'block';
             loadSellerClients();
+            loadSellerDays();
         } else {
             if (waBtn) waBtn.style.display = 'block';
             if (uploadBtn) uploadBtn.style.display = 'block';
@@ -163,6 +164,56 @@ async function loadSellerClients() {
     } catch (err) {
         console.error('[Autocomplete] Error loading clients:', err);
     }
+}
+
+let storeSellerDays = [];
+
+function formatStoreDayLabel(input) {
+    if (!input) return 'Fecha';
+    let iso = String(input);
+    if (/^\d{4}-\d{2}-\d{2}T/.test(iso)) iso = iso.slice(0, 10);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) return String(input);
+    const d = new Date(iso + 'T00:00:00Z');
+    if (isNaN(d.getTime())) return iso;
+    const weekdays = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
+    const months = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'];
+    return `${weekdays[d.getUTCDay()]} ${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+async function loadSellerDays() {
+    if (!storeAuthUser || !storeActiveSeller) return;
+    try {
+        const headers = getAuthHeaders();
+        const daysRes = await fetch(`/api/days?seller_id=${storeActiveSeller.id}`, { headers });
+        if (!daysRes.ok) return;
+        const days = await daysRes.json();
+        if (Array.isArray(days)) {
+            // Sort by date descending (most recent first)
+            storeSellerDays = days.sort((a, b) => new Date(b.day) - new Date(a.day));
+            updateDateSelectorUI();
+        }
+    } catch (err) {
+        console.error('[Store] Error loading seller days:', err);
+    }
+}
+
+function updateDateSelectorUI() {
+    const select = document.getElementById('store-order-date-select');
+    if (!select) return;
+    select.innerHTML = '';
+    
+    if (storeSellerDays.length <= 1) {
+        select.style.display = 'none';
+        return;
+    }
+
+    storeSellerDays.forEach(d => {
+        const opt = document.createElement('option');
+        opt.value = d.id;
+        opt.textContent = formatStoreDayLabel(d.day);
+        select.appendChild(opt);
+    });
+    select.style.display = 'block';
 }
 
 function setupClientAutocomplete() {
@@ -329,6 +380,9 @@ async function executeCheckout(customerName) {
     const newClientWhatsApp = document.getElementById('new-client-whatsapp');
     const whatsappValue = (newClientWhatsApp ? newClientWhatsApp.value : '') || customerNameInput.dataset.whatsapp || '';
     
+    const dateSelect = document.getElementById('store-order-date-select');
+    const selectedDayId = (dateSelect && dateSelect.style.display !== 'none') ? dateSelect.value : null;
+
     const saleItems = [];
     for (const productId in cart) {
         saleItems.push({ 
@@ -346,7 +400,8 @@ async function executeCheckout(customerName) {
         items: saleItems,
         seller: storeActiveSeller,
         user: storeAuthUser,
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
+        sale_day_id: selectedDayId
     };
 
     // 1. Queue immediately
@@ -487,13 +542,20 @@ async function processSingleSale(sale) {
         const actorName = sale.user ? (sale.user.name || sale.user.username) : 'Tienda Online';
 
         // 1. Parallelize Initial Lookups (Days and Desserts)
+        let targetDayId = sale.sale_day_id || null;
+        let daysPromise;
+        if (!targetDayId) {
+            daysPromise = fetch(`/api/days?seller_id=${sale.seller.id}`, { headers: authHeaders }).catch(e => ({ ok: false }));
+        } else {
+            daysPromise = Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+        }
+
         const [daysRes, dessertsRes] = await Promise.all([
-            fetch(`/api/days?seller_id=${sale.seller.id}`, { headers: authHeaders }).catch(e => ({ ok: false })),
+            daysPromise,
             fetch('/api/desserts', { headers: authHeaders }).catch(e => ({ ok: false }))
         ]);
 
-        let targetDayId = null;
-        if (daysRes.ok) {
+        if (!targetDayId && daysRes.ok) {
             const days = await daysRes.json();
             const targetDay = days[0];
             if (targetDay) targetDayId = targetDay.id;

--- a/public/store-transactions.js
+++ b/public/store-transactions.js
@@ -193,8 +193,8 @@ async function loadSellerDays() {
         if (!daysRes.ok) return;
         const days = await daysRes.json();
         if (Array.isArray(days)) {
-            // Sort by date descending (most recent first)
-            storeSellerDays = days.sort((a, b) => new Date(b.day) - new Date(a.day));
+            // Sort by date ascending (closest date first on the left, furthest on the right)
+            storeSellerDays = days.sort((a, b) => new Date(a.day) - new Date(b.day));
             updateDateSelectorUI();
         }
     } catch (err) {

--- a/public/store.html
+++ b/public/store.html
@@ -1264,6 +1264,61 @@
             border-color: var(--primary);
             color: var(--primary);
         }
+
+        /* Contenedor de tarjetas de fecha en Checkout */
+        .store-date-cards-wrapper {
+            display: flex;
+            gap: 8px;
+            width: 100%;
+            overflow-x: auto;
+            padding: 2px 0;
+            scrollbar-width: none;
+        }
+        .store-date-cards-wrapper::-webkit-scrollbar {
+            display: none;
+        }
+
+        /* Tarjeta individual */
+        .store-date-card {
+            flex: 1;
+            min-width: 90px;
+            padding: 6px 10px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--surface);
+            text-align: center;
+            cursor: pointer;
+            transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            user-select: none;
+        }
+
+        .store-date-card:hover {
+            border-color: var(--primary);
+            background: rgba(226, 122, 144, 0.04);
+        }
+
+        .store-date-card.active {
+            border-color: var(--primary);
+            background: rgba(226, 122, 144, 0.08);
+            outline: 1.5px solid var(--primary);
+        }
+
+        .store-date-card-day {
+            font-size: 11px;
+            font-weight: 700;
+            color: var(--text);
+            text-transform: capitalize;
+        }
+
+        .store-date-card-date {
+            font-size: 9px;
+            color: var(--muted);
+            margin-top: 2px;
+        }
     </style>
 </head>
 
@@ -1451,7 +1506,7 @@
         <div class="internal-checkout-container" id="internal-checkout-container">
             <input type="text" id="store-customer-name" class="internal-checkout-input"
                 placeholder="Nombre de tu cliente" autocomplete="off">
-            <select id="store-order-date-select" class="internal-checkout-input" style="display: none; margin-top: 4px;"></select>
+            <div id="store-order-date-container" class="store-date-cards-wrapper" style="display: none; margin-top: 6px;"></div>
             <ul id="store-client-dropdown" class="custom-client-dropdown"></ul>
         </div>
 

--- a/public/store.html
+++ b/public/store.html
@@ -1451,6 +1451,7 @@
         <div class="internal-checkout-container" id="internal-checkout-container">
             <input type="text" id="store-customer-name" class="internal-checkout-input"
                 placeholder="Nombre de tu cliente" autocomplete="off">
+            <select id="store-order-date-select" class="internal-checkout-input" style="display: none; margin-top: 4px;"></select>
             <ul id="store-client-dropdown" class="custom-client-dropdown"></ul>
         </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -8528,3 +8528,33 @@ td.col-client.action-bar-fading .client-input {
 	from { opacity: 0; transform: scale(0.95) translateY(10px); }
 	to { opacity: 1; transform: scale(1) translateY(0); }
 }
+
+/* Ocultación de postres inactivos en popovers */
+.new-sale-popover .hidden-dessert-cell {
+	display: none !important;
+}
+
+/* Botón de expansión "Mostrar más postres" */
+.show-more-desserts-btn {
+	grid-column: 1 / 3;
+	text-align: center;
+	padding: 8px;
+	margin-top: 4px;
+	border: 1px dashed var(--border);
+	border-radius: 8px;
+	color: var(--primary);
+	font-weight: 600;
+	font-size: 13px;
+	cursor: pointer;
+	background: transparent;
+	transition: background-color 0.2s, border-color 0.2s;
+}
+
+.show-more-desserts-btn:hover {
+	background-color: var(--secondary);
+	border-color: var(--primary);
+}
+
+[data-theme="dark"] .show-more-desserts-btn:hover {
+	background-color: rgba(255, 255, 255, 0.05);
+}


### PR DESCRIPTION
Este PR implementa la visualizacion dinamica de postres en los popovers de nuevo pedido y edicion. Por defecto, solo se muestran los postres con movimiento hoy (o los activos en la tienda si no hay ventas aun). Los restantes se ocultan bajo el boton 'Mostrar mas postres'.