### PR TITLE
feat: reactivar sondeo temporal por 2 minutos al bloquear acceso

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1074,7 +1074,8 @@ async function fetchWithVersion(url, options = {}) {
 	// Check for version mismatch or forced logout
 	if (res.status === 426 || res.status === 403) {
 		try {
-			const data = await res.json();
+			const clone = res.clone();
+			const data = await clone.json();
 			if (data.action === 'force_reload' || data.action === 'force_logout') {
 				forceLogoutAndReload(data.message || 'Tu aplicación está desactualizada');
 				throw new Error('force_reload'); // Prevent further execution
@@ -1102,7 +1103,8 @@ async function api(method, url, body) {
 	// Check for version mismatch or forced logout
 	if (res.status === 426 || res.status === 403) {
 		try {
-			const data = await res.json();
+			const clone = res.clone();
+			const data = await clone.json();
 			if (data.action === 'force_reload' || data.action === 'force_logout') {
 				forceLogoutAndReload(data.message || 'Tu aplicación está desactualizada');
 				return; // Prevent further execution
@@ -1112,6 +1114,15 @@ async function api(method, url, body) {
 
 	if (!res.ok) {
 		const text = await res.text();
+		if (text.includes('production_access_denied') && window.KitchenManager) {
+			console.warn("⚠️ Production access was revoked by admin. Locking kitchen view immediately...");
+			try {
+				window.KitchenManager.stopIntervals();
+				window.KitchenManager.checkAccess();
+			} catch (err) {
+				console.error("Error invoking KitchenManager lock on access denial:", err);
+			}
+		}
 		throw new Error(`API ${method} ${url} failed: ${res.status} ${text}`);
 	}
 	return res.json();

--- a/public/kitchen-manager.js
+++ b/public/kitchen-manager.js
@@ -18,6 +18,7 @@ const KitchenManager = {
         }
         console.log("👨‍🍳 Initializing Kitchen Manager...");
         this.bindEvents();
+        this.setupSecurity();
         
         const hasAccess = await this.checkAccess();
         if (hasAccess) {
@@ -1995,6 +1996,7 @@ const KitchenManager = {
                 goHomeBtn.textContent = 'Inicio';
             }
             this.stopLockPolling();
+            this.updateWatermark();
             return true;
         }
 
@@ -2033,6 +2035,7 @@ const KitchenManager = {
                 document.getElementById('kitchen-blocked-content')?.classList.add('hidden');
                 document.getElementById('kitchen-active-content')?.classList.remove('hidden');
                 this.stopLockPolling();
+                this.updateWatermark();
                 return true;
             }
         } catch (e) {
@@ -2063,6 +2066,7 @@ const KitchenManager = {
                     this.stopLockPolling();
                     document.getElementById('kitchen-blocked-content')?.classList.add('hidden');
                     document.getElementById('kitchen-active-content')?.classList.remove('hidden');
+                    this.updateWatermark();
                     
                     // Reload active kitchen data
                     await this.loadData();
@@ -2119,6 +2123,103 @@ const KitchenManager = {
         } catch (err) {
             console.error("Error loading admin production access controls:", err);
         }
+    },
+
+    setupSecurity() {
+        // 1. Add style tag for security features (blur and watermark)
+        if (!document.getElementById('kitchen-security-styles')) {
+            const style = document.createElement('style');
+            style.id = 'kitchen-security-styles';
+            style.textContent = `
+                .kitchen-blur-active {
+                    filter: blur(15px) grayscale(100%);
+                    pointer-events: none;
+                    user-select: none;
+                    transition: filter 0.15s ease-out;
+                }
+                .kitchen-watermark-overlay {
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    width: 100vw;
+                    height: 100vh;
+                    z-index: 999999;
+                    pointer-events: none;
+                    overflow: hidden;
+                    display: grid;
+                    grid-template-columns: repeat(4, 1fr);
+                    grid-template-rows: repeat(6, 1fr);
+                    gap: 20px;
+                    opacity: 0.04;
+                    user-select: none;
+                }
+                .watermark-item {
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-size: 1.1rem;
+                    font-weight: 900;
+                    color: #000;
+                    transform: rotate(-25deg);
+                    white-space: nowrap;
+                }
+            `;
+            document.head.appendChild(style);
+        }
+
+        // 2. Setup blur on focus loss listeners
+        const handleBlur = () => {
+            const activeContent = document.getElementById('kitchen-active-content');
+            if (activeContent) {
+                activeContent.classList.add('kitchen-blur-active');
+            }
+        };
+
+        const handleFocus = () => {
+            const activeContent = document.getElementById('kitchen-active-content');
+            if (activeContent) {
+                activeContent.classList.remove('kitchen-blur-active');
+            }
+        };
+
+        // Window events
+        window.addEventListener('blur', handleBlur);
+        window.addEventListener('focus', handleFocus);
+        
+        // Tab visibility events
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) {
+                handleBlur();
+            } else {
+                handleFocus();
+            }
+        });
+    },
+
+    updateWatermark() {
+        // Remove existing watermark if any
+        document.getElementById('kitchen-watermark')?.remove();
+
+        const activeContent = document.getElementById('kitchen-active-content');
+        if (!activeContent) return;
+
+        const username = window.state?.currentUser?.name || window.state?.currentUser?.username || 'Usuario';
+        const dateStr = new Date().toLocaleDateString('es-CO', { day: '2-digit', month: '2-digit', year: 'numeric' });
+        
+        const watermarkContainer = document.createElement('div');
+        watermarkContainer.id = 'kitchen-watermark';
+        watermarkContainer.className = 'kitchen-watermark-overlay';
+
+        // Fill the grid with watermark texts
+        const totalItems = 24; // 4x6 grid
+        for (let i = 0; i < totalItems; i++) {
+            const item = document.createElement('div');
+            item.className = 'watermark-item';
+            item.textContent = `${username} - ${dateStr} - Lulitas`;
+            watermarkContainer.appendChild(item);
+        }
+
+        activeContent.appendChild(watermarkContainer);
     }
 };
 

--- a/public/kitchen-manager.js
+++ b/public/kitchen-manager.js
@@ -1996,7 +1996,6 @@ const KitchenManager = {
                 goHomeBtn.textContent = 'Inicio';
             }
             this.stopLockPolling();
-            this.updateWatermark();
             return true;
         }
 
@@ -2035,7 +2034,6 @@ const KitchenManager = {
                 document.getElementById('kitchen-blocked-content')?.classList.add('hidden');
                 document.getElementById('kitchen-active-content')?.classList.remove('hidden');
                 this.stopLockPolling();
-                this.updateWatermark();
                 return true;
             }
         } catch (e) {
@@ -2066,7 +2064,6 @@ const KitchenManager = {
                     this.stopLockPolling();
                     document.getElementById('kitchen-blocked-content')?.classList.add('hidden');
                     document.getElementById('kitchen-active-content')?.classList.remove('hidden');
-                    this.updateWatermark();
                     
                     // Reload active kitchen data
                     await this.loadData();
@@ -2126,7 +2123,7 @@ const KitchenManager = {
     },
 
     setupSecurity() {
-        // 1. Add style tag for security features (blur and watermark)
+        // 1. Add style tag for security features (blur)
         if (!document.getElementById('kitchen-security-styles')) {
             const style = document.createElement('style');
             style.id = 'kitchen-security-styles';
@@ -2136,32 +2133,6 @@ const KitchenManager = {
                     pointer-events: none;
                     user-select: none;
                     transition: filter 0.15s ease-out;
-                }
-                .kitchen-watermark-overlay {
-                    position: fixed;
-                    top: 0;
-                    left: 0;
-                    width: 100vw;
-                    height: 100vh;
-                    z-index: 999999;
-                    pointer-events: none;
-                    overflow: hidden;
-                    display: grid;
-                    grid-template-columns: repeat(4, 1fr);
-                    grid-template-rows: repeat(6, 1fr);
-                    gap: 20px;
-                    opacity: 0.04;
-                    user-select: none;
-                }
-                .watermark-item {
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    font-size: 1.1rem;
-                    font-weight: 900;
-                    color: #000;
-                    transform: rotate(-25deg);
-                    white-space: nowrap;
                 }
             `;
             document.head.appendChild(style);
@@ -2194,32 +2165,6 @@ const KitchenManager = {
                 handleFocus();
             }
         });
-    },
-
-    updateWatermark() {
-        // Remove existing watermark if any
-        document.getElementById('kitchen-watermark')?.remove();
-
-        const activeContent = document.getElementById('kitchen-active-content');
-        if (!activeContent) return;
-
-        const username = window.state?.currentUser?.name || window.state?.currentUser?.username || 'Usuario';
-        const dateStr = new Date().toLocaleDateString('es-CO', { day: '2-digit', month: '2-digit', year: 'numeric' });
-        
-        const watermarkContainer = document.createElement('div');
-        watermarkContainer.id = 'kitchen-watermark';
-        watermarkContainer.className = 'kitchen-watermark-overlay';
-
-        // Fill the grid with watermark texts
-        const totalItems = 24; // 4x6 grid
-        for (let i = 0; i < totalItems; i++) {
-            const item = document.createElement('div');
-            item.className = 'watermark-item';
-            item.textContent = `${username} - ${dateStr} - Lulitas`;
-            watermarkContainer.appendChild(item);
-        }
-
-        activeContent.appendChild(watermarkContainer);
     }
 };
 

--- a/public/kitchen-manager.js
+++ b/public/kitchen-manager.js
@@ -44,6 +44,7 @@ const KitchenManager = {
             clearInterval(this._syncInterval);
             this._syncInterval = null;
         }
+        this.stopLockPolling();
     },
 
     async syncActiveTimersSilently() {
@@ -216,6 +217,8 @@ const KitchenManager = {
                         this.startIntervals();
                     } else {
                         window.notify.error("El acceso aún está cerrado.");
+                        // Restart the 2-minute polling window
+                        this.startLockPolling();
                     }
                 } catch (err) {
                     console.error("Error rechecking access:", err);
@@ -1991,6 +1994,7 @@ const KitchenManager = {
             if (goHomeBtn) {
                 goHomeBtn.textContent = 'Inicio';
             }
+            this.stopLockPolling();
             return true;
         }
 
@@ -2019,13 +2023,16 @@ const KitchenManager = {
                     msgEl.textContent = `Próxima fecha de producción: ${nextProduction}`;
                 }
                 
-                // Clear any running intervals so no background requests are sent
+                // Clear active kitchen intervals
                 this.stopIntervals();
+                // Start the 2-minute auto-unlock polling window
+                this.startLockPolling();
                 return false;
             } else {
                 // Access approved, show active content and hide blocked screen
                 document.getElementById('kitchen-blocked-content')?.classList.add('hidden');
                 document.getElementById('kitchen-active-content')?.classList.remove('hidden');
+                this.stopLockPolling();
                 return true;
             }
         } catch (e) {
@@ -2033,6 +2040,57 @@ const KitchenManager = {
             // Default to let it load if settings API fails
             return true;
         }
+    },
+
+    startLockPolling() {
+        this.stopLockPolling(); // Clear any existing intervals/timeouts
+        console.log("🔐 Starting production access lock polling (10s checks, 2m timeout)...");
+        
+        // 1. Setup the 10-second polling interval
+        this._lockPollingInterval = setInterval(async () => {
+            try {
+                const settings = await window.api('GET', '/api/store-settings');
+                const approved = settings.production_access_approved === 'true';
+                const nextProduction = settings.next_production_datetime || 'Pendiente de confirmación';
+                
+                const msgEl = document.getElementById('kitchen-next-production-msg');
+                if (msgEl) {
+                    msgEl.textContent = `Próxima fecha de producción: ${nextProduction}`;
+                }
+
+                if (approved) {
+                    console.log("🔓 Production access approved! Unlocking dynamically...");
+                    this.stopLockPolling();
+                    document.getElementById('kitchen-blocked-content')?.classList.add('hidden');
+                    document.getElementById('kitchen-active-content')?.classList.remove('hidden');
+                    
+                    // Reload active kitchen data
+                    await this.loadData();
+                    // Resume normal sync checks
+                    this.startIntervals();
+                }
+            } catch (err) {
+                console.error("Lock polling error:", err);
+            }
+        }, 10000); // Check every 10 seconds
+
+        // 2. Setup the 2-minute (120,000 ms) auto-expiration timeout
+        this._lockPollingTimeout = setTimeout(() => {
+            console.log("⏰ 2-minute wait screen timeout reached. Stopping background polling...");
+            this.stopLockPolling();
+        }, 120000);
+    },
+
+    stopLockPolling() {
+        if (this._lockPollingInterval) {
+            clearInterval(this._lockPollingInterval);
+            this._lockPollingInterval = null;
+        }
+        if (this._lockPollingTimeout) {
+            clearTimeout(this._lockPollingTimeout);
+            this._lockPollingTimeout = null;
+        }
+        console.log("🔓 Stopped production access lock polling.");
     },
 
     async loadAdminControls() {

--- a/scratch/test_double_read_fix.js
+++ b/scratch/test_double_read_fix.js
@@ -1,0 +1,133 @@
+import fs from 'fs';
+import path from 'path';
+import { JSDOM } from 'jsdom';
+
+// Load index.html content
+const htmlPath = path.resolve('public/index.html');
+const htmlContent = fs.readFileSync(htmlPath, 'utf8');
+
+// Create JSDOM instance
+const dom = new JSDOM(htmlContent, {
+    url: "http://localhost/index.html",
+    runScripts: "dangerously"
+});
+
+const { window } = dom;
+
+// Mock window.matchMedia for JSDOM
+window.matchMedia = window.matchMedia || function() {
+    return {
+        matches: false,
+        addListener: function() {},
+        removeListener: function() {}
+    };
+};
+
+// Mock globals needed by app.js
+window.state = {
+    currentUser: {
+        username: 'jaimes',
+        role: 'user',
+        features: ['produccion']
+    }
+};
+
+window.notify = {
+    success: (msg) => console.log(`[Notify Success] ${msg}`),
+    error: (msg) => console.log(`[Notify Error] ${msg}`)
+};
+
+// Create a custom mock for fetch that supports clone()
+let mockResponseData = {
+    status: 403,
+    ok: false,
+    json: async () => ({ error: 'production_access_denied', message: 'El acceso a la cocina está cerrado' }),
+    text: async () => JSON.stringify({ error: 'production_access_denied', message: 'El acceso a la cocina está cerrado' })
+};
+
+window.fetch = async (url, options) => {
+    // Return a Response-like object that supports cloning
+    const makeResponse = (bodyRead = false) => {
+        let isRead = bodyRead;
+        return {
+            status: mockResponseData.status,
+            ok: mockResponseData.ok,
+            clone: () => {
+                if (isRead) throw new TypeError("Failed to execute 'clone' on 'Response': body stream already read");
+                return makeResponse(false);
+            },
+            json: async () => {
+                if (isRead) throw new TypeError("Failed to execute 'json' on 'Response': body stream already read");
+                isRead = true;
+                return mockResponseData.json();
+            },
+            text: async () => {
+                if (isRead) throw new TypeError("Failed to execute 'text' on 'Response': body stream already read");
+                isRead = true;
+                return mockResponseData.text();
+            }
+        };
+    };
+    return makeResponse(false);
+};
+
+// Load app.js in window context
+const appJsPath = path.resolve('public/app.js');
+const appJsContent = fs.readFileSync(appJsPath, 'utf8');
+window.eval(appJsContent);
+
+// Mock window.KitchenManager
+let checkAccessCalled = false;
+let stopIntervalsCalled = false;
+
+window.KitchenManager = {
+    isProductionUser: () => true,
+    stopIntervals: () => {
+        stopIntervalsCalled = true;
+        console.log("Mock KitchenManager.stopIntervals() invoked");
+    },
+    checkAccess: async () => {
+        checkAccessCalled = true;
+        console.log("Mock KitchenManager.checkAccess() invoked");
+        return false;
+    }
+};
+
+async function runTests() {
+    console.log("🚀 Running API Stream and Proactive Lock Test...");
+
+    try {
+        // Trigger a request that returns 403 production_access_denied
+        await window.api('GET', '/api/inventory?action=production_sync_check');
+        console.error("FAIL: Expected API call to throw a 403 error, but it succeeded!");
+        process.exit(1);
+    } catch (e) {
+        console.log("Caught expected error:", e.message);
+        
+        // Assert that it did NOT throw a body stream already read TypeError
+        if (e.message.includes("body stream already read")) {
+            console.error("FAIL: TypeError body stream already read was thrown!");
+            process.exit(1);
+        } else {
+            console.log("✅ PASS: Correct error thrown, no stream consumption TypeError detected.");
+        }
+    }
+
+    // Assert that KitchenManager was proactively called to lock the UI
+    console.log("KitchenManager.stopIntervals() called:", stopIntervalsCalled);
+    console.log("KitchenManager.checkAccess() called:", checkAccessCalled);
+
+    if (stopIntervalsCalled && checkAccessCalled) {
+        console.log("✅ PASS: KitchenManager was proactively called to lock the UI.");
+        console.log("\n🎉 ALL API STREAM AND PROACTIVE LOCK TESTS PASSED!");
+        process.exit(0);
+    } else {
+        console.error("FAIL: KitchenManager was not proactively called on access denial.");
+        process.exit(1);
+    }
+}
+
+runTests().catch(err => {
+    console.error("Test execution crashed:", err);
+    process.exit(1);
+});

--- a/scratch/test_kitchen_lock_polling.js
+++ b/scratch/test_kitchen_lock_polling.js
@@ -1,0 +1,249 @@
+import fs from 'fs';
+import path from 'path';
+import { JSDOM } from 'jsdom';
+
+// Load index.html content
+const htmlPath = path.resolve('public/index.html');
+const htmlContent = fs.readFileSync(htmlPath, 'utf8');
+
+// Create a JSDOM instance with scripts enabled
+const dom = new JSDOM(htmlContent, {
+    url: "http://localhost/index.html",
+    runScripts: "dangerously"
+});
+
+const { window } = dom;
+
+// Mock window globals and functions
+window.state = {
+    currentUser: {
+        role: 'produccion',
+        name: 'jaimes'
+    }
+};
+
+window.notify = {
+    success: (msg) => console.log(`[Notify Success] ${msg}`),
+    error: (msg) => console.log(`[Notify Error] ${msg}`)
+};
+
+// Mock the window.api function to capture requests
+const apiCalls = [];
+let apiResponse = { production_access_approved: 'false', next_production_datetime: '27 de Junio, 2:00 pm' };
+
+window.api = async (method, endpoint, data) => {
+    apiCalls.push({ method, endpoint, data, timestamp: Date.now() });
+    if (endpoint === '/api/store-settings') {
+        return apiResponse;
+    }
+    if (endpoint === '/api/inventory?action=production_sync_check') {
+        return { last_change: 'some-timestamp' };
+    }
+    return [];
+};
+
+// Load and evaluate kitchen-manager.js in the JSDOM context
+const jsPath = path.resolve('public/kitchen-manager.js');
+let jsContent = fs.readFileSync(jsPath, 'utf8');
+
+// Evaluate the script in the DOM window context
+window.eval(jsContent);
+
+// Extract KitchenManager from window
+const km = window.KitchenManager;
+if (!km) {
+    console.error("FAIL: KitchenManager not loaded into JSDOM window");
+    process.exit(1);
+}
+
+// Mock methods that load external data so we focus on access / polling logic
+km.loadData = async () => {
+    console.log("Mocked loadData called");
+};
+
+// Mock timers (setInterval and setTimeout) to control time
+const originalSetInterval = global.setInterval;
+const originalClearInterval = global.clearInterval;
+const originalSetTimeout = global.setTimeout;
+const originalClearTimeout = global.clearTimeout;
+
+const activeIntervals = new Map();
+const activeTimeouts = new Map();
+let timerIdCounter = 1;
+
+global.setInterval = (fn, delay) => {
+    const id = timerIdCounter++;
+    activeIntervals.set(id, { fn, delay });
+    return id;
+};
+
+global.clearInterval = (id) => {
+    activeIntervals.delete(id);
+};
+
+global.setTimeout = (fn, delay) => {
+    const id = timerIdCounter++;
+    activeTimeouts.set(id, { fn, delay });
+    return id;
+};
+
+global.clearTimeout = (id) => {
+    activeTimeouts.delete(id);
+};
+
+// Also map JSDOM window functions
+window.setInterval = global.setInterval;
+window.clearInterval = global.clearInterval;
+window.setTimeout = global.setTimeout;
+window.clearTimeout = global.clearTimeout;
+
+// Helper to fast-forward time asynchronously
+async function advanceTime(ms) {
+    console.log(`⏱️ Fast-forwarding time by ${ms} ms...`);
+    
+    // Check timeouts
+    const timeoutsToRun = [];
+    for (const [id, t] of activeTimeouts.entries()) {
+        t.delay -= ms;
+        if (t.delay <= 0) {
+            timeoutsToRun.push({ id, fn: t.fn });
+        }
+    }
+    // Run timeouts that expired
+    timeoutsToRun.sort((a,b) => a.id - b.id).forEach(({ id, fn }) => {
+        activeTimeouts.delete(id);
+        fn();
+    });
+
+    // Check intervals
+    for (const [id, interval] of activeIntervals.entries()) {
+        // Run the interval fn if delay has passed
+        let remaining = ms;
+        while (remaining >= interval.delay) {
+            // Run the interval and wait for its microtasks to finish
+            interval.fn();
+            remaining -= interval.delay;
+        }
+    }
+    
+    // Flush the promise queue so async operations inside interval functions can run
+    await new Promise(resolve => originalSetTimeout(resolve, 10));
+}
+
+async function runTests() {
+    console.log("🚀 Starting DOM Lock Polling Test Suite...");
+
+    // Test 1: Check access closed initially starts polling
+    console.log("\n--- Test 1: Initializing while blocked starts 10s interval & 2m timeout ---");
+    apiResponse = { production_access_approved: 'false', next_production_datetime: '27 de Junio, 2:00 pm' };
+    apiCalls.length = 0;
+    
+    await km.init();
+
+    // Verify view state
+    const isBlockedHidden = window.document.getElementById('kitchen-blocked-content').classList.contains('hidden');
+    const isActiveHidden = window.document.getElementById('kitchen-active-content').classList.contains('hidden');
+    console.log("Blocked screen visible (expected true):", !isBlockedHidden);
+    console.log("Active screen hidden (expected true):", isActiveHidden);
+    
+    if (isBlockedHidden || !isActiveHidden) {
+        console.error("FAIL: Incorrect visibility states when access is closed");
+        process.exit(1);
+    }
+
+    // Verify polling timers exist
+    console.log("Active intervals (expected 1):", activeIntervals.size);
+    console.log("Active timeouts (expected 1):", activeTimeouts.size);
+    if (activeIntervals.size !== 1 || activeTimeouts.size !== 1) {
+        console.error("FAIL: Did not setup polling interval or timeout");
+        process.exit(1);
+    }
+
+    // Test 2: Polling calls API every 10 seconds
+    console.log("\n--- Test 2: Polling calls API every 10 seconds ---");
+    apiCalls.length = 0;
+    
+    await advanceTime(30000); // 30 seconds
+    console.log("API calls during 30s polling (expected 3):", apiCalls.filter(c => c.endpoint === '/api/store-settings').length);
+    if (apiCalls.filter(c => c.endpoint === '/api/store-settings').length !== 3) {
+        console.error("FAIL: Polling did not check API every 10s");
+        process.exit(1);
+    }
+
+    // Test 3: Polling expires after 2 minutes (120 seconds total)
+    console.log("\n--- Test 3: Polling automatically stops after 2 minutes ---");
+    apiCalls.length = 0;
+    // We already advanced 30s. Advance 95s more to reach 125s total (> 120s)
+    await advanceTime(95000);
+    
+    console.log("Active intervals after 2 minutes (expected 0):", activeIntervals.size);
+    console.log("Active timeouts after 2 minutes (expected 0):", activeTimeouts.size);
+    if (activeIntervals.size !== 0 || activeTimeouts.size !== 0) {
+        console.error("FAIL: Polling timers were not cleaned up after 2 minutes");
+        process.exit(1);
+    }
+
+    // Confirm no more calls are made after expiration
+    apiCalls.length = 0;
+    await advanceTime(30000);
+    console.log("API calls after expiration (expected 0):", apiCalls.filter(c => c.endpoint === '/api/store-settings').length);
+    if (apiCalls.filter(c => c.endpoint === '/api/store-settings').length !== 0) {
+        console.error("FAIL: Polling continued after expiration");
+        process.exit(1);
+    }
+
+    // Test 4: Clicking recheck button restarts the 2-minute window
+    console.log("\n--- Test 4: Clicking 'Reintentar' restarts the 2-minute polling window ---");
+    const recheckBtn = window.document.getElementById('kitchen-recheck-btn');
+    if (!recheckBtn) {
+        console.error("FAIL: 'Reintentar' button not found in DOM");
+        process.exit(1);
+    }
+
+    apiCalls.length = 0;
+    // Simulate click
+    await recheckBtn.onclick();
+    // Flush promise queue to allow onclick async calls to process
+    await new Promise(resolve => originalSetTimeout(resolve, 10));
+
+    // Verify immediate call is made
+    console.log("Immediate check made (expected at least 1 API call):", apiCalls.length > 0);
+    console.log("Active intervals restarted (expected 1):", activeIntervals.size);
+    console.log("Active timeouts restarted (expected 1):", activeTimeouts.size);
+    if (activeIntervals.size !== 1 || activeTimeouts.size !== 1) {
+        console.error("FAIL: 'Reintentar' did not restart the 2-minute polling timers");
+        process.exit(1);
+    }
+
+    // Test 5: Dynamic unlock when approved
+    console.log("\n--- Test 5: Dynamic unlock during polling when access is approved ---");
+    apiResponse = { production_access_approved: 'true', next_production_datetime: '27 de Junio, 2:00 pm' };
+    apiCalls.length = 0;
+
+    // Advance 10s to trigger next interval tick
+    await advanceTime(10000);
+
+    const isBlockedHiddenNow = window.document.getElementById('kitchen-blocked-content').classList.contains('hidden');
+    const isActiveHiddenNow = window.document.getElementById('kitchen-active-content').classList.contains('hidden');
+    console.log("Blocked screen hidden after approval (expected true):", isBlockedHiddenNow);
+    console.log("Active screen visible after approval (expected true):", !isActiveHiddenNow);
+    
+    console.log("Lock polling interval is null (expected true):", km._lockPollingInterval === null);
+    console.log("Lock polling timeout is null (expected true):", km._lockPollingTimeout === null);
+    
+    // Verify that active kitchen intervals were resumed
+    console.log("Active kitchen intervals started (expected 2):", activeIntervals.size);
+    
+    if (!isBlockedHiddenNow || isActiveHiddenNow || km._lockPollingInterval !== null || km._lockPollingTimeout !== null || activeIntervals.size !== 2) {
+        console.error("FAIL: Did not unlock dynamically or stop lock polling properly");
+        process.exit(1);
+    }
+
+    console.log("\n🎉 ALL DOM/FRONTEND LOCK POLLING TESTS PASSED SUCCESSFULLY!");
+    process.exit(0);
+}
+
+runTests().catch(err => {
+    console.error("Test suite crashed:", err);
+    process.exit(1);
+});


### PR DESCRIPTION
Implementa sondeo temporal de 2 minutos (120,000 ms) cuando la cocina se encuentra bloqueada, reanudando las consultas cada 10s si el usuario presiona 'Reintentar' o si la pantalla de espera se activa inicialmente. Pasa exitosamente todas las pruebas de backend e integración DOM.